### PR TITLE
Enable exclude vendor

### DIFF
--- a/lookout/core/data_requests.py
+++ b/lookout/core/data_requests.py
@@ -58,8 +58,7 @@ def request_changes(stub: DataStub, url: str, commit_from: str, commit_to: str,
     request.base.hash = commit_from
     request.head.internal_repository_url = url
     request.head.hash = commit_to
-    request.exclude_vendored = False
-    # TODO(vmarkovtsev): change to True once https://github.com/src-d/lookout/pull/92 is merged
+    request.exclude_vendored = True
     request.want_contents = contents
     request.want_uast = uast
     return stub.GetChanges(request)
@@ -75,8 +74,7 @@ def request_files(stub: DataStub, url: str, commit: str, contents: bool,
     request = FilesRequest()
     request.revision.internal_repository_url = url
     request.revision.hash = commit
-    request.exclude_vendored = False
-    # TODO(vmarkovtsev): change to True once https://github.com/src-d/lookout/pull/92 is merged
+    request.exclude_vendored = True
     request.want_contents = contents
     request.want_uast = uast
     return stub.GetFiles(request)


### PR DESCRIPTION
The bug in lookout was fixed. Please use new binary: https://github.com/src-d/lookout/releases/tag/v0.0.3