### PR TITLE
Improve sklearn compatibility

### DIFF
--- a/lookout/style/format/tests/test_format_model.py
+++ b/lookout/style/format/tests/test_format_model.py
@@ -28,7 +28,8 @@ class FormatModelTests(unittest.TestCase):
             fm2 = FormatModel().load(f.name)
             self.assertEqual(fm1.languages, fm2.languages)
             for lang in fm1.languages:
-                self.assertEqual(fm1[lang].get_params(False), fm2[lang].get_params(False))
+                self.assertEqual(fm1[lang].get_saved_params(),
+                                 fm2[lang].get_saved_params())
                 for rule1, rule2 in zip(fm1[lang]._rules, fm2[lang]._rules):
                     self.assertEqual(rule1.stats[0], rule2.stats[0])
                     self.assertAlmostEqual(rule1.stats[1], rule2.stats[1])
@@ -58,8 +59,7 @@ class FormatModelTests(unittest.TestCase):
         self.assertEqual(len(fm), 2)
 
     def test_set_unfitted_item(self):
-        model = tree.DecisionTreeClassifier(min_samples_leaf=26, random_state=1989)
-        rules = Rules(model, prune_branches=False, prune_attributes=False)
+        rules = Rules(self.model, prune_branches=False, prune_attributes=False)
         fm = FormatModel()
         with self.assertRaises(ValueError):
             fm[""] = rules

--- a/lookout/style/format/tests/test_rules.py
+++ b/lookout/style/format/tests/test_rules.py
@@ -4,6 +4,7 @@ import unittest
 import numpy
 import pandas
 from sklearn import model_selection, tree, ensemble
+from sklearn.exceptions import NotFittedError
 
 from lookout.style.format.rules import Rules
 
@@ -39,6 +40,11 @@ def load_abalone_data(filepath=os.path.join(os.path.dirname(__file__), "abalone.
 class RulesTests(unittest.TestCase):
     def setUp(self):
         self.train_x, self.test_x, self.train_y, self.test_y = load_abalone_data()
+
+    def test_set_unfitted_item(self):
+        model = tree.DecisionTreeClassifier(min_samples_leaf=26, random_state=1989)
+        with self.assertRaises(NotFittedError):
+            Rules(model, prune_branches=False, prune_attributes=False)
 
     def test_tree_no_pruning(self):
         model = tree.DecisionTreeClassifier(min_samples_leaf=26, random_state=1989)


### PR DESCRIPTION
Use external functions instead of `get_params` and `_get_param_names` to decide which parameters to save in the `modelforge.Model`. Fit the base model if not fitted to allow for convenient CV workflows in sklearn.

Signed-off-by: Hugo Mougard <hugo@sourced.tech>