### PR TITLE
Implement the training of FormatAnalyzer

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -1,12 +1,18 @@
+from collections import defaultdict
 import logging
+from pprint import pformat
 
 from bblfsh import Node
+from skopt import BayesSearchCV
+from skopt.space import Categorical, Integer
 
 from lookout.core.analyzer import Analyzer, AnalyzerModel, ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2_grpc import DataStub
 from lookout.core.data_requests import with_changed_uasts_and_contents, with_uasts_and_contents
+from lookout.style.format.features import FeatureExtractor
 from lookout.style.format.model import FormatModel
+from lookout.style.format.rules import TrainableRules
 
 
 class FormatAnalyzer(Analyzer):
@@ -35,24 +41,83 @@ class FormatAnalyzer(Analyzer):
     @with_uasts_and_contents
     def train(cls, ptr: ReferencePointer, config: dict, data_request_stub: DataStub,
               **data) -> AnalyzerModel:
-        cls.log.info("train %s %s %s", ptr.url, ptr.commit, data)
+        """
+        Train a model given the files available.
+
+        :param url: url of the repository
+        :param commit: hash of the commit that we analyze
+        :param config: configuration dict
+        :param data: data sent by the lookout server
+        :return: a modelforge.Model containing the learned rules, per language.
+        """
+        final_config = {
+            "siblings_window": 5,
+            "parents_depth": 2,
+            "lower_bound_instances": 500,
+            "prune_branches_algorithms": ("reduced-error",),
+            "top_down_greedy_budget": TrainableRules.TopDownGreedyBudget(False, .5),
+            "prune_attributes": False,
+            "uncertain_attributes": True,
+            "prune_dataset_ratio": .2,
+            "n_estimators": 10,
+            "random_state": 42,
+            "n_iter": 30
+        }
+        final_config.update(config)
+        cls.log.info("train %s %s %s with config %s", ptr.url, ptr.commit, data,
+                     pformat(final_config, width=4096, compact=True))
         files = data["files"]
+        language_to_files = defaultdict(list)
         for file in files:
+            if not len(file.uast.children):
+                continue
+            if file.language != "JavaScript":
+                continue
+            language_to_files["javascript"].append(file)
             cls.log.info("%s %s %d", file.path, file.language, len(file.uast.children))
 
-        """
-        Plan:
+        model = FormatModel().construct(cls, ptr)
 
-        1. Load all the File-s - they are streamed and we need to read them all into a list
-        2. Sort by language
-        3. Loop per language group:
-        4. extract_features()
-        5. train the base model - tree or forest
-        6. train the rules
-        7. generate the Modelforge model
-        """
-
-        return FormatModel().construct(cls, ptr)
+        for language, files in language_to_files.items():
+            cls.log.info("training on %d %s files", len(files), language)
+            fe = FeatureExtractor(language=language,
+                                  siblings_window=final_config["siblings_window"],
+                                  parents_depth=final_config["parents_depth"])
+            X, y = fe.extract_features(files)
+            lower_bound_instances = final_config["lower_bound_instances"]
+            if X.shape[0] < lower_bound_instances:
+                cls.log.warning("skipped %s: too few samples (%d/%d)", language, X.shape[0],
+                                lower_bound_instances)
+                continue
+            cls.log.debug("training rules model")
+            bscv = BayesSearchCV(
+                TrainableRules(
+                    prune_branches_algorithms=final_config["prune_branches_algorithms"],
+                    prune_attributes=final_config["prune_attributes"],
+                    top_down_greedy_budget=final_config["top_down_greedy_budget"],
+                    uncertain_attributes=final_config["uncertain_attributes"],
+                    prune_dataset_ratio=final_config["prune_dataset_ratio"],
+                    n_estimators=final_config["n_estimators"],
+                    random_state=final_config["random_state"]),
+                {"base_model_name": Categorical(["sklearn.ensemble.RandomForestClassifier",
+                                                 "sklearn.tree.DecisionTreeClassifier"]),
+                 "max_depth": Categorical([None, 5, 10]),
+                 "max_features": Categorical([None, "auto"]),
+                 "min_samples_split": Integer(2, 20),
+                 "min_samples_leaf": Integer(1, 20)},
+                n_jobs=-1,
+                n_iter=final_config["n_iter"])
+            bscv.fit(X, y)
+            cls.log.debug("score of the best estimator found: %.3f", bscv.best_score_)
+            cls.log.debug("params of the best estimator found: %s", str(bscv.best_params_))
+            cls.log.debug("training the model with complete data")
+            trainable_rules = TrainableRules(prune_branches_algorithms=["reduced-error"],
+                                             prune_attributes=True, random_state=42,
+                                             uncertain_attributes=True, **bscv.best_params_)
+            trainable_rules.fit(X, y)
+            model[language] = trainable_rules.rules
+        cls.log.info("trained %s", model)
+        return model
 
     @staticmethod
     def count_nodes(uast: Node):

--- a/lookout/style/format/tests/test_integration.py
+++ b/lookout/style/format/tests/test_integration.py
@@ -31,10 +31,12 @@ class IntegrationTests(unittest.TestCase):
         train_X, test_X, train_y, test_y = \
             model_selection.train_test_split(X, y, random_state=1989)
 
-        model = tree.DecisionTreeClassifier(min_samples_leaf=26, random_state=1989)
+        model = tree.DecisionTreeClassifier(min_samples_leaf=26, random_state=1989, max_depth=None,
+                                            max_features="auto", min_samples_split=2)
         model.fit(train_X, train_y)
-        rules = TrainableRules("sklearn.tree.DecisionTreeClassifier", prune_branches=False,
-                               prune_attributes=False, min_samples_leaf=26, random_state=1989)
+        rules = TrainableRules("sklearn.tree.DecisionTreeClassifier", prune_branches_algorithms=[],
+                               prune_attributes=False, min_samples_leaf=26, random_state=1989,
+                               max_depth=None, max_features="auto", min_samples_split=2)
         rules.fit(train_X, train_y)
         model_score_train = model.score(train_X, train_y)
         model_score_test = model.score(test_X, test_y)

--- a/lookout/style/format/tests/test_model.py
+++ b/lookout/style/format/tests/test_model.py
@@ -10,8 +10,9 @@ from lookout.style.format.tests.test_rules import load_abalone_data
 class FormatModelTests(unittest.TestCase):
     def setUp(self):
         (self.train_x, self.test_x, self.train_y, self.test_y), _, _ = load_abalone_data()
-        trainer = TrainableRules("sklearn.tree.DecisionTreeClassifier", prune_branches=False,
-                                 prune_attributes=False, min_samples_leaf=26, random_state=1989)
+        trainer = TrainableRules("sklearn.tree.DecisionTreeClassifier",
+                                 prune_branches_algorithms=[], prune_attributes=False,
+                                 min_samples_leaf=26, random_state=1989)
         trainer.fit(self.test_x, self.test_y)
         self.rules = trainer.rules
         self.fm = FormatModel().load(os.path.join(os.path.dirname(__file__), "format-model.asdf"))
@@ -27,6 +28,8 @@ class FormatModelTests(unittest.TestCase):
             fm2 = FormatModel().load(f.name)
             self.assertEqual(fm1.languages, fm2.languages)
             for lang in fm1.languages:
+                # clean None values in fm1 to match asdf cleaning:
+                fm1[lang]._origin = {k: v for k, v in fm1[lang]._origin.items() if v is not None}
                 self.assertEqual(fm1[lang].origin, fm2[lang].origin)
                 for rule1, rule2 in zip(fm1[lang].rules, fm2[lang].rules):
                     self.assertEqual(rule1.stats[0], rule2.stats[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psycopg2-binary==2.7.5
 scikit-learn==0.19.2
 tqdm==4.11.2
 modelforge==0.6.4
+scikit-optimize==0.5.2


### PR DESCRIPTION
The train method uses model selection to obtain the best possible set
of rules with a non destructive pruning method. We can then implement
destructive pruning if we need to further reduce the number of rules.

Signed-off-by: Hugo Mougard <hugo@sourced.tech>