### PR TITLE
Update lookout binary from 0.1.0 to 0.1.3 to match submodule version and update related tests

### DIFF
--- a/lookout/core/tests/server.py
+++ b/lookout/core/tests/server.py
@@ -17,7 +17,7 @@ def fetch():
     try:
         buffer = io.BytesIO()
         with urlopen("https://github.com/src-d/lookout/releases/download/"
-                     "v0.1.0/lookout_sdk_v0.1.0_linux_amd64.tar.gz") as response:
+                     "v0.1.3/lookout_sdk_v0.1.3_linux_amd64.tar.gz") as response:
             copyfileobj(response, buffer)
         buffer.seek(0)
         with tarfile.open(fileobj=buffer, mode="r:gz") as tar:

--- a/lookout/core/tests/test_data_requests.py
+++ b/lookout/core/tests/test_data_requests.py
@@ -101,7 +101,8 @@ class DataRequestsTests(unittest.TestCase, EventHandlers):
                 self.assertEqual(file.content, b"")
                 self.assertEqual(type(file.uast).__module__, bblfsh.Node.__module__)
                 self.assertTrue(file.path)
-                self.assertIn(file.language, ("Python", ""))
+                self.assertIn(file.language, ("Python", "YAML", "Dockerfile", "Markdown",
+                                              "Jupyter Notebook", "Shell", "Text", ""))
 
         func = with_uasts(func)
         func(self,
@@ -119,7 +120,8 @@ class DataRequestsTests(unittest.TestCase, EventHandlers):
                     self.assertGreater(len(file.content), 0, file.path)
                 self.assertEqual(type(file.uast).__module__, bblfsh.Node.__module__)
                 self.assertTrue(file.path)
-                self.assertIn(file.language, ("Python", ""))
+                self.assertIn(file.language, ("Python", "YAML", "Dockerfile", "Markdown",
+                                              "Jupyter Notebook", "Shell", "Text", ""))
 
         func = with_uasts_and_contents(func)
         func(self,


### PR DESCRIPTION
The two latest `lookout` submodule updates didn't bump the binary used to perform the tests. Here is the bump.