### PR TITLE
Rename test_integration.py to more informative name test_rules_integration.py

### DIFF
--- a/lookout/style/format/tests/test_rules_integration.py
+++ b/lookout/style/format/tests/test_rules_integration.py
@@ -10,7 +10,7 @@ from lookout.style.format.features import FeatureExtractor
 from lookout.style.format.rules import TrainableRules
 
 
-class IntegrationTests(unittest.TestCase):
+class RulesIntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         base = Path(__file__).parent


### PR DESCRIPTION
Will help to distinguish with other types of integration tests.