### PR TITLE
Remove hard-filtering of empty nodes

### DIFF
--- a/lookout/style/format/features.py
+++ b/lookout/style/format/features.py
@@ -28,8 +28,6 @@ class VirtualNode:
         self.value = value
         assert start.line >= 1 and start.col >= 1, "start line and column are 1-based like UASTs"
         assert end.line >= 1 and end.col >= 1, "end line and column are 1-based like UASTs"
-        assert (y in [CLASS_INDEX[CLS_NOOP], CLASS_INDEX[CLS_TAB_DEC], CLASS_INDEX[CLS_SPACE_DEC]]
-                or start.offset != end.offset)
         self.start = start
         self.end = end
         self.node = node


### PR DESCRIPTION
@EgorBu reported many failed parses which I could easily reproduce. While I investigate it's necessary to remove this hard-filtering.