### PR TITLE
Quality checking

### DIFF
--- a/lookout/style/format/__main__.py
+++ b/lookout/style/format/__main__.py
@@ -1,0 +1,60 @@
+import argparse
+import sys
+
+from lookout.core.cmdline import ArgumentDefaultsHelpFormatterNoNone
+from lookout.style.format.quality_report import quality_report
+from lookout.style.format.visualization import visualize
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatterNoNone)
+    subparsers = parser.add_subparsers(help="Commands", dest="command")
+
+    def add_parser(name, help):
+        return subparsers.add_parser(
+            name, help=help, formatter_class=ArgumentDefaultsHelpFormatterNoNone)
+
+    # Evaluation
+    eval_parser = add_parser("eval", "Evaluate trained model on given dataset.")
+    eval_parser.set_defaults(handler=quality_report)
+    eval_parser.add_argument("-i", "--input", required=True, type=str,
+                             help="Path to folder with source code - "
+                                  "should be in a format compatible with glob (ends with**/* "
+                                  "and surrounded by quotes. Ex: `path/**/*`).")
+    eval_parser.add_argument("--bblfsh", default="0.0.0.0:9432",
+                             help="Babelfish server's address.")
+    eval_parser.add_argument("-l", "--language", default="javascript",
+                             help="Programming language to use.")
+    eval_parser.add_argument("-n", "--n-files", default=0, type=int,
+                             help="How many files with most mispredictions to show. "
+                                  "If n <= 0 show all.")
+    eval_parser.add_argument("-m", "--model", required=True, help="Path to saved FormatModel.")
+
+    # Visualization
+    vis_parser = add_parser("vis", "Visualize mispredictions of the model on the given file.")
+    vis_parser.set_defaults(handler=visualize)
+    vis_parser.add_argument("-i", "--input", required=True, help="Path to folder with source "
+                                                                 "code.")
+    vis_parser.add_argument("--bblfsh", default="0.0.0.0:9432",
+                            help="Babelfish server's address.")
+    vis_parser.add_argument("-l", "--language", default="javascript",
+                            help="Programming language to use.")
+    vis_parser.add_argument("-m", "--model", required=True, help="Path to saved FormatModel.")
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    try:
+        handler = args.handler
+    except AttributeError:
+        def print_usage(_):
+            parser.print_usage()
+
+        handler = print_usage
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lookout/style/format/quality_report.py
+++ b/lookout/style/format/quality_report.py
@@ -1,0 +1,66 @@
+from collections import Counter
+import glob
+import os
+
+import bblfsh
+from bblfsh.client import NonUTF8ContentException
+import numpy
+from sklearn.metrics import classification_report,confusion_matrix
+from tqdm import tqdm
+
+from lookout.core.api.service_data_pb2 import File
+from lookout.style.format.features import FeatureExtractor, CLASSES
+from lookout.style.format.model import FormatModel
+
+
+def prepare_files(folder, client, language):
+    files = []
+
+    # collect filenames with full path
+    filenames = glob.glob(folder, recursive=True)
+
+    for file in tqdm(filenames):
+        if not os.path.isfile(file):
+            continue
+        try:
+            res = client.parse(file)
+        except NonUTF8ContentException:
+            # skip files that can't be parsed because of UTF-8 decoding errors.
+            continue
+        if res.status == 0 and res.language.lower() == language.lower():
+            uast = res.uast
+            path = file
+            with open(file) as f:
+                content = f.read().encode("utf-8")
+            files.append(File(content=content, uast=uast, path=path))
+    return files
+
+
+def quality_report(args):
+    client = bblfsh.BblfshClient(args.bblfsh)
+    files = prepare_files(args.input, client, args.language)
+    print("Number of files: %s" % (len(files)))
+
+    fe = FeatureExtractor(language=args.language)
+    X, y, nodes = fe.extract_features(files)
+
+    analyzer = FormatModel().load(args.model)
+    rules = analyzer._rules_by_lang[args.language]
+    y_pred = rules.predict(X)
+
+    target_names = [CLASSES[cls_ind] for cls_ind in numpy.unique(y)]
+    print("Classification report:\n" + classification_report(y, y_pred, target_names=target_names))
+    print("Confusion matrix:\n" + str(confusion_matrix(y, y_pred)))
+
+    # sort files by mispredictions and print them
+    file_mispred = []
+    for gt, pred, vn in zip(y, y_pred, nodes):
+        if gt != pred:
+            file_mispred.append(vn.path)
+    file_stat = Counter(file_mispred)
+
+    to_show = file_stat.most_common()
+    if args.n_files > 0:
+        to_show = to_show[:args.n_files]
+
+    print("Files with most errors:\n" + "\n".join(map(str, to_show)))

--- a/lookout/style/format/visualization.py
+++ b/lookout/style/format/visualization.py
@@ -1,0 +1,69 @@
+from collections import namedtuple
+import os
+
+import bblfsh
+
+from lookout.core.api.service_data_pb2 import File
+from lookout.style.format.features import FeatureExtractor, CLASSES
+from lookout.style.format.model import FormatModel
+
+RED = "\033[41m"
+GREEN = "\033[42m"
+ENDC = '\033[m'
+
+
+Misprediction = namedtuple("Misprediction", ["y", "pred", "node"])
+
+
+def prepare_file(filename, client, language):
+    assert os.path.isfile(filename), "\"%s\" should be a file" % filename
+    res = client.parse(filename, language)
+    assert res.status == 0, "Parse returned status %s for file %s" % (res.status, filename)
+    error_log = "Language for % should be %s instead of %s"
+    assert res.language.lower() == language.lower(), error_log % (filename, language, res.language)
+
+    with open(filename) as f:
+        content = f.read().encode("utf-8")
+
+    return File(content=content, uast=res.uast, path=filename)
+
+
+def visualize(args):
+    client = bblfsh.BblfshClient(args.bblfsh)
+    file = prepare_file(args.input, client, args.language)
+
+    fe = FeatureExtractor(language=args.language)
+    X, y, nodes = fe.extract_features([file])
+
+    analyzer = FormatModel().load(args.model)
+    rules = analyzer._rules_by_lang[args.language]
+    y_pred = rules.predict(X)
+
+    mispred = []
+    for gt, pred, node in zip(y, y_pred, nodes):
+        if gt != pred:
+            mispred.append(Misprediction(gt, pred, node))
+    print("Errors: %s out of %s mispredicted" % (len(mispred), len(nodes)))
+
+    mispred = sorted(mispred, key=lambda r: r.node.start.offset)
+
+    new_content = ENDC
+    old_content = file.content.decode("utf-8")
+    for i in range(len(mispred)):
+        wrong = mispred[i]
+        start = wrong.node.start.offset
+        end = wrong.node.end.offset
+        if end == start:
+            end = start + len(wrong.node.value)
+
+        if i == 0 and start != 0:
+            new_content += old_content[:start]
+
+        new_content += GREEN + CLASSES[wrong.y] + RED + CLASSES[wrong.pred] + ENDC
+
+        if i == len(mispred) - 1 and end != len(old_content):
+            new_content += old_content[end:]
+        else:
+            new_content += old_content[end:mispred[i + 1].node.start.offset]
+
+    print("Visualization:\n" + new_content)


### PR DESCRIPTION
* dataset level - classification report & bad files
* file level - misprediction visualization

Example of usage:
```console
egor@egor-sourced:~/workspace/style-analyzer$ python3 -m lookout.style.format eval -i '/home/egor/workspace/tmp/freeCodeCamp/**/*' -m /tmp/home/egor/workspace/tmp/freeCodeCamp/FormatAnalyzer_1.asdf -n 10
/usr/local/lib/python3.5/dist-packages/sklearn/ensemble/weight_boosting.py:29: DeprecationWarning: numpy.core.umath_tests is an internal NumPy module and should not be imported. It will be removed in a future NumPy release.
  from numpy.core.umath_tests import inner1d
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 543/543 [00:09<00:00, 58.55it/s]
Number of files: 258
could not parse file /home/egor/workspace/tmp/freeCodeCamp/common/utils/encode-decode.js with error "missed some imaginary tokens: "
  /<form[^>]*>/,
  "', skipping
Classification report:
             precision    recall  f1-score   support

  <newline>       0.83      0.96      0.89     24944
   <+space>       0.93      0.95      0.94      9773
   <-space>       0.84      0.82      0.83      9771
          '       0.59      0.93      0.72      9156
          "       1.00      0.67      0.80     28704
     <noop>       1.00      1.00      1.00    345314

avg / total       0.97      0.97      0.97    427662

Confusion matrix:
[[ 23982    205    331    336     10     80]
 [   293   9322     67     63     11     17]
 [   268    317   8052      0      0   1134]
 [   487    121      9   8521     14      4]
 [  3786     58      0   5578  19268     14]
 [    16      0   1138      3      0 344157]]
Files with most errors:
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fontawesome-all.min.js', 4019)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fa-solid.min.js', 1994)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fa-brands.min.js', 1012)
('/home/egor/workspace/tmp/freeCodeCamp/server/resources/testimonials.json', 812)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fontawesome.min.js', 579)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fa-regular.min.js', 434)
('/home/egor/workspace/tmp/freeCodeCamp/public/json/bootcamps.json', 411)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fontawesome-all.js', 369)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/lib/fontawesome/fontawesome.js', 282)
('/home/egor/workspace/tmp/freeCodeCamp/public/js/calculator.js', 199)
```
for mistakes visualization - colors are not shown in github
```console
egor@egor-sourced:~/workspace/style-analyzer$ python3 -m lookout.style.format vis -i /home/egor/workspace/tmp/freeCodeCamp/seed/challengeTitles.js -m /tmp/home/egor/workspace/tmp/freeCodeCamp/FormatAnalyzer_1.asdf 
/usr/local/lib/python3.5/dist-packages/sklearn/ensemble/weight_boosting.py:29: DeprecationWarning: numpy.core.umath_tests is an internal NumPy module and should not be imported. It will be removed in a future NumPy release.
  from numpy.core.umath_tests import inner1d
Errors: 2 out of 280 mispredicted
Visualization:
class ChallengeTitles {
  constructor() {
    this.knownTitles = [];
<-space><+space>  }
  check(title) {
    if (typeof title !== 'string') {
      throw new Error(`
        Expected a valid string for ${title}, but got a(n) ${typeof title}
      `);
    } else if (title.length === 0) {
      throw new Error(`
        Expected a title length greater than 0
      `);
    }
    const titleToCheck = title.toLowerCase().replace(/\s+/g, '');
    const isKnown = this.knownTitles.includes(titleToCheck);
    if (isKnown) {
      throw new Error(`
    All challenges must have a unique title.

    The title ${title} is already assigned
    `);
    }
    this.knownTitles = [ ...this.knownTitles, titleToCheck ];
  }
<-space><+space>}

export default ChallengeTitles;
```