### PR TITLE
Exclude garbage from lookout data requests

### DIFF
--- a/lookout/core/data_requests.py
+++ b/lookout/core/data_requests.py
@@ -8,6 +8,7 @@ from lookout.core.analyzer import Analyzer, AnalyzerModel, ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2 import ChangesRequest, FilesRequest, Change, File
 from lookout.core.api.service_data_pb2_grpc import DataStub
+from lookout.core.garbage_exclusion import GARBAGE_PATTERN
 from lookout.core.ports import Type
 
 
@@ -130,6 +131,7 @@ def request_changes(stub: DataStub, ptr_from: ReferencePointer, ptr_to: Referenc
              into a synchronous call, but in practice, that function call hangs for some reason.
     """
     request = ChangesRequest(base=ptr_from.to_pb(), head=ptr_to.to_pb())
+    request.exclude_pattern = GARBAGE_PATTERN
     request.exclude_vendored = True
     request.want_contents = contents
     request.want_uast = uast
@@ -144,6 +146,7 @@ def request_files(stub: DataStub, ptr: ReferencePointer, contents: bool, uast: b
     :return: The stream of the gRPC invocation results.
     """
     request = FilesRequest(revision=ptr.to_pb())
+    request.exclude_pattern = GARBAGE_PATTERN
     request.exclude_vendored = True
     request.want_contents = contents
     request.want_uast = uast

--- a/lookout/core/garbage_exclusion.py
+++ b/lookout/core/garbage_exclusion.py
@@ -1,0 +1,15 @@
+"""Pattern to filter out garbage files."""
+from importlib import import_module
+from pathlib import Path
+from typing import Iterable
+
+
+def _gather_patterns() -> Iterable[str]:
+    """Return available patterns to filter out garbage files from the langs package."""
+    for path in (Path(__file__).parent / "langs").iterdir():
+        if path.is_dir():
+            if (path / "garbage.py").is_file():
+                yield import_module("lookout.core.langs.%s.garbage" % path.name).GARBAGE_PATTERN
+
+
+GARBAGE_PATTERN = "|".join(_gather_patterns())

--- a/lookout/core/langs/javascript/garbage.py
+++ b/lookout/core/langs/javascript/garbage.py
@@ -1,0 +1,1 @@
+GARBAGE_PATTERN = r"^.*[.-]min\.js"

--- a/lookout/style/format/__main__.py
+++ b/lookout/style/format/__main__.py
@@ -1,13 +1,20 @@
-import argparse
+"""Utilities to check the quality of a model on a given dataset and to visualize its errors."""
+from argparse import ArgumentParser
 import sys
+from typing import Any
 
 from lookout.core.cmdline import ArgumentDefaultsHelpFormatterNoNone
 from lookout.style.format.quality_report import quality_report
 from lookout.style.format.visualization import visualize
 
 
-def create_parser():
-    parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatterNoNone)
+def create_parser() -> ArgumentParser:
+    """
+    Create a parser for the lookout.style.format utility.
+
+    :return: an ArgumentParser with an handler defined in the handler attribute.
+    """
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatterNoNone)
     subparsers = parser.add_subparsers(help="Commands")
 
     def add_parser(name, help):
@@ -43,7 +50,8 @@ def create_parser():
     return parser
 
 
-def main():
+def main() -> Any:
+    """Entry point of the utility."""
     parser = create_parser()
     args = parser.parse_args()
     try:

--- a/lookout/style/format/files_filtering.py
+++ b/lookout/style/format/files_filtering.py
@@ -1,0 +1,30 @@
+"""Facilities to filter files during debugging."""
+from os.path import isfile
+import re
+from typing import Iterable, Optional
+
+from lookout.core.garbage_exclusion import GARBAGE_PATTERN
+
+
+def filter_filepaths(filepaths: Iterable[str], line_length_limit: int = 500,
+                     exclude_pattern: Optional[str] = None) -> Iterable[str]:
+    """
+    Mirror of the file filtering used in the format analyzer for use by debugging tools.
+
+    :param paths: Iterable of paths to filter.
+    :param line_length_limit: Maximum length of lines to keep a file.
+    :param exclude_pattern: Pattern to reject files based on their path. If None, uses the pattern
+                            currently in use in lookout.core. Use "" to not filter anything.
+    :return Iterable of paths, filtered.
+    """
+    if exclude_pattern is None:
+        exclude_pattern = GARBAGE_PATTERN
+    exclude_compiled_pattern = re.compile(exclude_pattern) if exclude_pattern else None
+    for filepath in filepaths:
+        if not isfile(filepath):
+            continue
+        if exclude_compiled_pattern and exclude_compiled_pattern.search(filepath):
+            continue
+        with open(filepath, 'rb') as fh:
+            if len(max(fh, key=len, default=b"")) <= line_length_limit:
+                yield filepath

--- a/lookout/style/format/quality_report.py
+++ b/lookout/style/format/quality_report.py
@@ -1,27 +1,34 @@
+"""Facilities to report the quality of a given model on a given dataset."""
 from collections import Counter
 import glob
-import os
+from typing import Iterable
 
 from bblfsh import BblfshClient
 from bblfsh.client import NonUTF8ContentException
 import numpy
-from sklearn.metrics import classification_report,confusion_matrix
+from sklearn.metrics import classification_report, confusion_matrix
 from tqdm import tqdm
 
 from lookout.core.api.service_data_pb2 import File
 from lookout.style.format.features import FeatureExtractor, CLASSES
+from lookout.style.format.files_filtering import filter_filepaths
 from lookout.style.format.model import FormatModel
 
 
-def prepare_files(folder, client, language):
+def prepare_files(folder: str, client: BblfshClient, language: str) -> Iterable[File]:
+    """
+    Prepare the given folder for analysis by extracting UASTs and creating the gRPC wrappers.
+
+    :param folder: Path to the folder to analyze.
+    :param client: Babelfish client. Babelfish server should be started accordingly.
+    :param language: Language to consider. Will discard the other languages
+    """
     files = []
 
     # collect filenames with full path
     filenames = glob.glob(folder, recursive=True)
 
-    for file in tqdm(filenames):
-        if not os.path.isfile(file):
-            continue
+    for file in tqdm(filter_filepaths(filenames)):
         try:
             res = client.parse(file)
         except NonUTF8ContentException:
@@ -36,8 +43,9 @@ def prepare_files(folder, client, language):
     return files
 
 
-def quality_report(input_pattern: str, bblfsh: str, language: str, n_files: int,
-                   model: str) -> None:
+def quality_report(input_pattern: str, bblfsh: str, language: str, n_files: int, model: str
+                   ) -> None:
+    """Print several different reports for a given model on a given dataset."""
     client = BblfshClient(bblfsh)
     files = prepare_files(input_pattern, client, language)
     print("Number of files: %s" % (len(files)))

--- a/lookout/style/format/tests/test_analyzer.py
+++ b/lookout/style/format/tests/test_analyzer.py
@@ -93,6 +93,15 @@ class AnalyzerTests(unittest.TestCase):
         comments = analyzer.analyze(self.ptr, self.ptr, datastub)
         self.assertGreater(len(comments), 0)
 
+    def test_file_filtering(self):
+        datastub = FakeDataStub(files=self.base_files.values(), changes=None)
+        config = {"n_iter": 1, "line_length_limit": 0}
+        model_trained = FormatAnalyzer.train(self.ptr, config, datastub)
+        self.assertEqual(len(model_trained._rules_by_lang), 0)
+        config = {"n_iter": 1, "line_length_limit": 500}
+        model_trained = FormatAnalyzer.train(self.ptr, config, datastub)
+        self.assertGreater(len(model_trained._rules_by_lang), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lookout/style/format/visualization.py
+++ b/lookout/style/format/visualization.py
@@ -1,10 +1,11 @@
+"""Utilities to visualize the errors made on a file."""
 from collections import namedtuple
 import os
 
 from bblfsh import BblfshClient
 
 from lookout.core.api.service_data_pb2 import File
-from lookout.style.format.features import FeatureExtractor, CLASSES
+from lookout.style.format.features import CLASSES, FeatureExtractor
 from lookout.style.format.model import FormatModel
 
 RED = "\033[41m"
@@ -15,7 +16,14 @@ ENDC = '\033[m'
 Misprediction = namedtuple("Misprediction", ["y", "pred", "node"])
 
 
-def prepare_file(filename, client, language):
+def prepare_file(filename: str, client: BblfshClient, language: str) -> File:
+    """
+    Prepare the given file for analysis by extracting UAST and creating the gRPC wrapper.
+
+    :param filename: Path to the filename to analyze.
+    :param client: Babelfish client. Babelfish server should be started accordingly.
+    :param language: Language to consider. Will discard the other languages
+    """
     assert os.path.isfile(filename), "\"%s\" should be a file" % filename
     res = client.parse(filename, language)
     assert res.status == 0, "Parse returned status %s for file %s" % (res.status, filename)
@@ -29,6 +37,7 @@ def prepare_file(filename, client, language):
 
 
 def visualize(input_filename: str, bblfsh: str, language: str, model: str) -> None:
+    """Visualize the errors made on a single file."""
     client = BblfshClient(bblfsh)
     file = prepare_file(input_filename, client, language)
 


### PR DESCRIPTION
Uses the lookout server exclude pattern and mirrors this behavior for debugging tools in a separate function. Also filters on max line length.