### PR TITLE
Refactor debugging facilities into a separate dir and add training script

### DIFF
--- a/lookout/style/format/debug/__main__.py
+++ b/lookout/style/format/debug/__main__.py
@@ -4,8 +4,10 @@ import sys
 from typing import Any
 
 from lookout.core.cmdline import ArgumentDefaultsHelpFormatterNoNone
-from lookout.style.format.quality_report import quality_report
-from lookout.style.format.visualization import visualize
+from lookout.core.slogging import setup
+from lookout.style.format.debug.quality_report import quality_report
+from lookout.style.format.debug.train import train
+from lookout.style.format.debug.visualization import visualize
 
 
 def create_parser() -> ArgumentParser:
@@ -20,6 +22,23 @@ def create_parser() -> ArgumentParser:
     def add_parser(name, help):
         return subparsers.add_parser(
             name, help=help, formatter_class=ArgumentDefaultsHelpFormatterNoNone)
+
+    # Training
+    training_parser = add_parser("train", "Train a FormatModel for debugging purposes.")
+    training_parser.set_defaults(handler=train)
+    training_parser.add_argument("training_dir",
+                                 help="Path to the directory containing the files to train from.")
+    training_parser.add_argument("output_path",
+                                 help="Path to the model to write.")
+    training_parser.add_argument("--bblfsh",
+                                 default="0.0.0.0:9432",
+                                 help="Address of the babelfish server.")
+    training_parser.add_argument("--language",
+                                 default="javascript",
+                                 help="Language to filter on.")
+    training_parser.add_argument("--config",
+                                 help="Path to a YAML file containing config to apply during "
+                                      "training.")
 
     # Evaluation
     eval_parser = add_parser("eval", "Evaluate trained model on given dataset.")
@@ -54,6 +73,7 @@ def main() -> Any:
     """Entry point of the utility."""
     parser = create_parser()
     args = parser.parse_args()
+    setup("DEBUG", False)
     try:
         handler = args.handler
         delattr(args, "handler")

--- a/lookout/style/format/debug/train.py
+++ b/lookout/style/format/debug/train.py
@@ -1,0 +1,45 @@
+"""Facilities to train a FormatModel without a lookout server."""
+from os.path import join
+from typing import Iterable
+
+from bblfsh.client import BblfshClient
+from yaml import safe_load
+
+from lookout.core.analyzer import ReferencePointer
+from lookout.core.api.service_data_pb2 import File
+from lookout.style.format.analyzer import FormatAnalyzer
+from lookout.style.format.debug.utils import prepare_files
+
+
+class _FakeDataStub:
+    def __init__(self, files: Iterable[File]) -> None:
+        self.files = files
+
+    def GetFiles(self, _) -> Iterable[File]:
+        return self.files
+
+
+def train(training_dir: str, output_path: str, language: str, bblfsh: str, config: str
+          ) -> None:
+    """
+    Train a FormatModel for debugging purposes.
+
+    :param training_dir: Path to the directory containing the files to train from.
+    :param output_path: Path to the model to write.
+    :param language: Language to filter on.
+    :param bblfsh: Address of the babelfish server.
+    :param config: Path to a YAML config to use during the training.
+    :return: Trained FormatModel.
+    """
+    bblfsh_client = BblfshClient(bblfsh)
+    if config is not None:
+        with open(config) as fh:
+            config = safe_load(fh)
+    else:
+        config = {}
+    model = FormatAnalyzer.train(ReferencePointer("someurl", "someref", "somecommit"),
+                                 config,
+                                 _FakeDataStub(files=prepare_files(join(training_dir, "**", "*"),
+                                                                   bblfsh_client,
+                                                                   language)))
+    model.save(output_path)

--- a/lookout/style/format/debug/utils.py
+++ b/lookout/style/format/debug/utils.py
@@ -1,0 +1,83 @@
+"""Utils for the debugging scripts."""
+from glob import glob
+from os.path import isfile
+import re
+from typing import Iterable, Optional
+
+from bblfsh.client import BblfshClient, NonUTF8ContentException
+from tqdm import tqdm
+
+from lookout.core.api.service_data_pb2 import File
+from lookout.core.garbage_exclusion import GARBAGE_PATTERN
+
+
+def filter_filepaths(filepaths: Iterable[str], line_length_limit: int = 500,
+                     exclude_pattern: Optional[str] = None) -> Iterable[str]:
+    """
+    Mirror of the file filtering used in the format analyzer for use by debugging tools.
+
+    :param paths: Iterable of paths to filter.
+    :param line_length_limit: Maximum length of lines to keep a file.
+    :param exclude_pattern: Pattern to reject files based on their path. If None, uses the pattern
+                            currently in use in lookout.core. Use "" to not filter anything.
+    :return Iterable of paths, filtered.
+    """
+    if exclude_pattern is None:
+        exclude_pattern = GARBAGE_PATTERN
+    exclude_compiled_pattern = re.compile(exclude_pattern) if exclude_pattern else None
+    for filepath in filepaths:
+        if not isfile(filepath):
+            continue
+        if exclude_compiled_pattern and exclude_compiled_pattern.search(filepath):
+            continue
+        with open(filepath, 'rb') as fh:
+            if len(max(fh, key=len, default=b"")) <= line_length_limit:
+                yield filepath
+
+
+def prepare_file(filename: str, client: BblfshClient, language: str) -> File:
+    """
+    Prepare the given file for analysis by extracting UAST and creating the gRPC wrapper.
+
+    :param filename: Path to the filename to analyze.
+    :param client: Babelfish client. Babelfish server should be started accordingly.
+    :param language: Language to consider. Will discard the other languages
+    """
+    assert isfile(filename), "\"%s\" should be a file" % filename
+    res = client.parse(filename, language)
+    assert res.status == 0, "Parse returned status %s for file %s" % (res.status, filename)
+    error_log = "Language for % should be %s instead of %s"
+    assert res.language.lower() == language.lower(), error_log % (filename, language, res.language)
+
+    with open(filename) as f:
+        content = f.read().encode("utf-8")
+
+    return File(content=content, uast=res.uast, path=filename)
+
+
+def prepare_files(folder: str, client: BblfshClient, language: str) -> Iterable[File]:
+    """
+    Prepare the given folder for analysis by extracting UASTs and creating the gRPC wrappers.
+
+    :param folder: Path to the folder to analyze.
+    :param client: Babelfish client. Babelfish server should be started accordingly.
+    :param language: Language to consider. Will discard the other languages
+    """
+    files = []
+
+    # collect filenames with full path
+    filenames = glob(folder, recursive=True)
+
+    for file in tqdm(filter_filepaths(filenames)):
+        try:
+            res = client.parse(file)
+        except NonUTF8ContentException:
+            # skip files that can't be parsed because of UTF-8 decoding errors.
+            continue
+        if res.status == 0 and res.language.lower() == language.lower():
+            uast = res.uast
+            path = file
+            with open(file) as f:
+                content = f.read().encode("utf-8")
+            files.append(File(content=content, uast=uast, path=path, language=res.language))
+    return files

--- a/lookout/style/format/debug/visualization.py
+++ b/lookout/style/format/debug/visualization.py
@@ -1,12 +1,12 @@
 """Utilities to visualize the errors made on a file."""
 from collections import namedtuple
-import os
 
 from bblfsh import BblfshClient
 
-from lookout.core.api.service_data_pb2 import File
 from lookout.style.format.features import CLASSES, FeatureExtractor
 from lookout.style.format.model import FormatModel
+from lookout.style.format.debug.utils import prepare_file
+
 
 RED = "\033[41m"
 GREEN = "\033[42m"
@@ -14,26 +14,6 @@ ENDC = '\033[m'
 
 
 Misprediction = namedtuple("Misprediction", ["y", "pred", "node"])
-
-
-def prepare_file(filename: str, client: BblfshClient, language: str) -> File:
-    """
-    Prepare the given file for analysis by extracting UAST and creating the gRPC wrapper.
-
-    :param filename: Path to the filename to analyze.
-    :param client: Babelfish client. Babelfish server should be started accordingly.
-    :param language: Language to consider. Will discard the other languages
-    """
-    assert os.path.isfile(filename), "\"%s\" should be a file" % filename
-    res = client.parse(filename, language)
-    assert res.status == 0, "Parse returned status %s for file %s" % (res.status, filename)
-    error_log = "Language for % should be %s instead of %s"
-    assert res.language.lower() == language.lower(), error_log % (filename, language, res.language)
-
-    with open(filename) as f:
-        content = f.read().encode("utf-8")
-
-    return File(content=content, uast=res.uast, path=filename)
 
 
 def visualize(input_filename: str, bblfsh: str, language: str, model: str) -> None:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     packages=find_packages(exclude=("lookout.style.format.tests",)),
     namespace_packages=["lookout"],
     entry_points={
-        "console_scripts": ["analyzer=lookout.__main__:main"],
+        "console_scripts": ["analyzer=lookout.__main__:main",
+                            "format-analyzer=lookout.style.format.debug.__main__:main"],
     },
     keywords=["machine learning on source code", "babelfish"],
     install_requires=["sourced-ml>=0.6.0,<0.7",


### PR DESCRIPTION
The format package had almost more debugging modules than normal ones so I moved everything to a debug package. I also added a training function since we all have it duplicated in our research code otherwise.