### PR TITLE
replace < and > by ` and ` in comments

### DIFF
--- a/lookout/style/format/features.py
+++ b/lookout/style/format/features.py
@@ -145,6 +145,7 @@ class VirtualNode:
         else:
             comment.text = "format: replace %s with %s at column %d" % (
                 CLASSES[self.y], CLASSES[correct_y], self.start.col)
+        comment.text = comment.text.replace("<", "`").replace(">", "`")
         return comment
 
 


### PR DESCRIPTION
because now it is invisible in comment:
```
format: replace <newline> with <space> at column 5
```
 converts to 
```
format: replace with at column 5
```