### PR TITLE
Fix asdf serialization error

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -92,7 +92,7 @@ class FormatAnalyzer(Analyzer):
         model = FormatModel().construct(cls, ptr)
         config = cls._load_config(config)
         for language, files in files_by_language.items():
-            lang_config = ChainMap(config.get(language, {}), config["global"])
+            lang_config = dict(ChainMap(config.get(language, {}), config["global"]))
             files = list(cls._filter_files(files, lang_config["line_length_limit"]))
             if len(files) == 0:
                 cls.log.info("Zero files after filtering, %s language is skipped.", language)


### PR DESCRIPTION
Fixes an error I've gotten after #152. @zurk if you can look into adding tests for this model serialization it'd be great, somehow we didn't catch that with travis!

```
Traceback (most recent call last):
  File "lookout/style/format/research/train.py", line 64, in <module>
    main()
  File "lookout/style/format/research/train.py", line 60, in main
    train(**vars(args))
  File "lookout/style/format/research/train.py", line 46, in train
    model.save(output_path)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/modelforge/model.py", line 274, in save
    self._write_tree(tree, output)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/modelforge/model.py", line 289, in _write_tree
    asdf.AsdfFile(final_tree).write_to(output, all_array_compression=ARRAY_COMPRESSION)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/asdf.py", line 1059, in write_to
    self._serial_write(fd, pad_blocks, include_block_index)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/asdf.py", line 820, in _serial_write
    self._write_tree(self._tree, fd, pad_blocks)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/asdf.py", line 781, in _write_tree
    yamlutil.dump_tree(tree, fd, self)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/yamlutil.py", line 336, in dump_tree
    tags=tags)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/__init__.py", line 188, in dump_all
    dumper.represent(data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 26, in represent
    node = self.represent_data(data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/yamlutil.py", line 78, in represent_data
    node = super(AsdfDumper, self).represent_data(data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 47, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/yamlutil.py", line 103, in represent_mapping
    None, mapping.data, flow_style)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 116, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/yamlutil.py", line 78, in represent_data
    node = super(AsdfDumper, self).represent_data(data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 47, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 197, in represent_list
    return self.represent_sequence('tag:yaml.org,2002:seq', data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 91, in represent_sequence
    node_item = self.represent_data(item)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/asdf/yamlutil.py", line 78, in represent_data
    node = super(AsdfDumper, self).represent_data(data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[None](self, data)
  File "/home/mog/.virtualenvs/style-analyzer/lib/python3.6/site-packages/yaml/representer.py", line 229, in represent_undefined
    raise RepresenterError("cannot represent an object: %s" % data)
yaml.representer.RepresenterError: cannot represent an object: ChainMap({}, {'feature_extractor': {'siblings_window': 5, 'parents_depth': 2, 'debug_parsing': False}, 'trainable_rules': {'prune_branches_algorithms': ['reduced-error'], 'top_down_greedy_budget': [False, 0.5], 'prune_attributes': False, 'uncertain_attributes': True, 'prune_dataset_ratio': 0.2, 'n_estimators': 10, 'random_state': 42, 'base_model_name': 'sklearn.tree.DecisionTreeClassifier', 'max_depth': 10, 'max_features': None, 'min_samples_leaf': 19, 'min_samples_split': 18}, 'n_iter': 5, 'line_length_limit': 500, 'lower_bound_instances': 500})
```