### PR TITLE
Fix "failed to parse this file" message confidence

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -64,7 +64,7 @@ class FormatAnalyzer(Analyzer):
                 if res is None:
                     comment = Comment()
                     comment.file = file.path
-                    comment.confidence = 1.
+                    comment.confidence = 100
                     comment.line = 1
                     comment.text = "Failed to parse this file"
                     continue


### PR DESCRIPTION
It should be an integer value, not the value from 0 to 1.
Related: https://github.com/src-d/style-analyzer/compare/master...zurk:fix/confidence?expand=1#diff-b71e0e71a29c83c6fa2ee406a76c3baeR81