### PR TITLE
Fix for 'missed some imaginary tokens` for regexp

### DIFF
--- a/lookout/style/format/features.py
+++ b/lookout/style/format/features.py
@@ -209,7 +209,6 @@ class FeatureExtractor:
         except ImportError:
             # It's normal for some languages not to have a uast_fixes module.
             self.node_fixtures = {}
-            pass
 
         # Order is important and should be consistent with _inplace_write_vnode_features function
         # where features generation happens.

--- a/lookout/style/format/features.py
+++ b/lookout/style/format/features.py
@@ -203,6 +203,13 @@ class FeatureExtractor:
         except ImportError:
             # It's normal for some languages not to have a token_unwrappers module.
             self.token_unwrappers = {}
+        try:
+            self.node_fixtures = importlib.import_module(
+                "lookout.style.format.langs.%s.uast_fixers" % language).NODE_FIXTURES
+        except ImportError:
+            # It's normal for some languages not to have a uast_fixes module.
+            self.node_fixtures = {}
+            pass
 
         # Order is important and should be consistent with _inplace_write_vnode_features function
         # where features generation happens.
@@ -680,6 +687,8 @@ class FeatureExtractor:
         queue = [root]
         while queue:
             node = queue.pop()
+            if node.internal_type in self.node_fixtures:
+                node = self.node_fixtures[node.internal_type](node)
             for child in node.children:
                 parents[id(child)] = node
             queue.extend(node.children)

--- a/lookout/style/format/langs/javascript/uast_fixers.py
+++ b/lookout/style/format/langs/javascript/uast_fixers.py
@@ -1,0 +1,15 @@
+from bblfsh import Node
+
+
+def fix_regexp_node(node: Node) -> Node:
+    """
+    Workaround for https://github.com/bblfsh/javascript-driver/issues/37
+    Should be removed as soon as issue closed and new driver is used.
+    """
+    node.token = node.properties["pattern"]
+    return node
+
+
+NODE_FIXTURES = {
+    "RegExpLiteral": fix_regexp_node,
+}

--- a/lookout/style/format/tests/test_features.py
+++ b/lookout/style/format/tests/test_features.py
@@ -34,6 +34,13 @@ class FeaturesTests(unittest.TestCase):
         nodes, parents = self.extractor._parse_file(code, uast, test_js_code_filepath)
         self.assertEqual("".join(n.value for n in nodes), code)
 
+    def test_parse_file_comment_after_regexp(self):
+        code = "x = // comment\n/<regexp>/;"
+        uast = bblfsh.BblfshClient("0.0.0.0:9432").parse(
+            filename="", language="javascript", contents=code.encode()).uast
+        nodes, parents = self.extractor._parse_file(code, uast, "")
+        self.assertEqual("".join(n.value for n in nodes), code)
+
     def test_parse_file(self):
         nodes, parents = self.extractor._parse_file(self.contents, self.uast, "test_file")
         text = []


### PR DESCRIPTION
Fixes https://github.com/src-d/style-analyzer/issues/180
Also, add a new test with code in the issue.
Signed-off-by: konstantin <kslavnov@gmail.com>