### PR TITLE
More statistics about rules & prettify 

### DIFF
--- a/lookout/style/format/__main__.py
+++ b/lookout/style/format/__main__.py
@@ -6,7 +6,7 @@ from typing import Any
 from lookout.core.cmdline import ArgumentDefaultsHelpFormatterNoNone
 from lookout.core.slogging import setup as setup_slogging
 from lookout.style.format.quality_report import quality_report
-from lookout.style.format.rule_stat import rules_report
+from lookout.style.format.rule_stat import print_rules_report
 from lookout.style.format.visualization import visualize
 
 
@@ -57,7 +57,7 @@ def create_parser() -> ArgumentParser:
 
     # Rules statistics
     rule_parser = add_parser("rule", "Statistics about rules.")
-    rule_parser.set_defaults(handler=rules_report)
+    rule_parser.set_defaults(handler=print_rules_report)
     rule_parser.add_argument("-i", "--input-pattern", required=True, type=str,
                              help="Path to folder with source code - "
                                   "should be in a format compatible with glob (ends with**/* "

--- a/lookout/style/format/quality_report.py
+++ b/lookout/style/format/quality_report.py
@@ -10,6 +10,7 @@ from sklearn.metrics import classification_report, confusion_matrix
 from tqdm import tqdm
 
 from lookout.core.api.service_data_pb2 import File
+from lookout.style.format.utils import profile
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.feature_utils import CLASSES
 from lookout.style.format.files_filtering import filter_filepaths
@@ -46,6 +47,7 @@ def prepare_files(folder: str, client: BblfshClient, language: str) -> Iterable[
     return files
 
 
+@profile
 def quality_report(input_pattern: str, bblfsh: str, language: str, n_files: int, model_path: str
                    ) -> None:
     """Print several different reports for a given model on a given dataset."""

--- a/lookout/style/format/quality_report.py
+++ b/lookout/style/format/quality_report.py
@@ -1,50 +1,15 @@
 """Facilities to report the quality of a given model on a given dataset."""
 from collections import Counter
-import glob
-from typing import Iterable
 
 from bblfsh import BblfshClient
-from bblfsh.client import NonUTF8ContentException
 import numpy
 from sklearn.metrics import classification_report, confusion_matrix
-from tqdm import tqdm
 
-from lookout.core.api.service_data_pb2 import File
 from lookout.style.format.utils import profile
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.feature_utils import CLASSES
-from lookout.style.format.files_filtering import filter_filepaths
 from lookout.style.format.model import FormatModel
-
-
-def prepare_files(folder: str, client: BblfshClient, language: str) -> Iterable[File]:
-    """
-    Prepare the given folder for analysis by extracting UASTs and creating the gRPC wrappers.
-
-    :param folder: Path to the folder to analyze.
-    :param client: Babelfish client. Babelfish server should be started accordingly.
-    :param language: Language to consider. Will discard the other languages
-    :return: Iterator of File-s with content, uast, path and language set.
-    """
-    files = []
-
-    # collect filenames with full path
-    filenames = glob.glob(folder, recursive=True)
-
-    for file in tqdm(filter_filepaths(filenames)):
-        try:
-            res = client.parse(file)
-        except NonUTF8ContentException:
-            # skip files that can't be parsed because of UTF-8 decoding errors.
-            continue
-        if res.status == 0 and res.language.lower() == language.lower():
-            uast = res.uast
-            path = file
-            with open(file) as f:
-                content = f.read().encode("utf-8")
-            files.append(File(content=content, uast=uast, path=path,
-                              language=res.language.lower()))
-    return files
+from lookout.style.format.utils import prepare_files
 
 
 @profile

--- a/lookout/style/format/rule_stat.py
+++ b/lookout/style/format/rule_stat.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from bblfsh import BblfshClient
 from tqdm import tqdm
 
-from lookout.style.format.descriptions import describe_rules
+from lookout.style.format.descriptions import describe_rule
+from lookout.style.format.utils import profile
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.feature_utils import CLASSES
 from lookout.style.format.model import FormatModel
@@ -46,22 +47,30 @@ def print_rule_table(rule_stat):
         print(new_line)
 
 
-def rules_report(input_pattern: str, bblfsh: str, language: str, model_path: str) -> None:
+@profile
+def print_rules_report(input_pattern: str, bblfsh: str, language: str, model_path: str) -> None:
     """Print several different reports for a given model on a given dataset."""
     model = FormatModel().load(model_path)
     rules = model[language]
     print("Model parameters: %s" % rules.origin_config)
     print("Stats about rules: %s" % rules)
 
+    fe = FeatureExtractor(language=language, **rules.origin_config["feature_extractor"])
+    min_support, max_support = float("inf"), -1
+    min_conf, max_conf = 1, 0
+    for i, rule in enumerate(rules.rules):
+        min_support = min(min_support, rule.stats.support)
+        max_support = max(max_support, rule.stats.support)
+        min_conf = min(min_conf, rule.stats.conf)
+        max_conf = max(max_conf, rule.stats.conf)
+        print("Rule %s: %s" % (i, describe_rule(rule, fe)))
+    print("Min/max support: %s/%s, min/max conf: %s/%s" % (min_support, max_support, min_conf,
+                                                           max_conf))
     client = BblfshClient(bblfsh)
     files = prepare_files(input_pattern, client, language)
     print("Number of files: %s" % (len(files)))
 
-    fe = FeatureExtractor(language=language, **rules.origin_config["feature_extractor"])
     res = fe.extract_features(files)
-
-    for i, rule in enumerate(describe_rules(rules.rules, fe)):
-        print("Rule %s: %s" % (i, rule))
 
     if res is None:
         print("Failed to parse files, aborting report...")

--- a/lookout/style/format/rule_stat.py
+++ b/lookout/style/format/rule_stat.py
@@ -9,7 +9,7 @@ from lookout.style.format.utils import profile
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.feature_utils import CLASSES
 from lookout.style.format.model import FormatModel
-from lookout.style.format.quality_report import prepare_files
+from lookout.style.format.utils import prepare_files
 
 
 class RuleStat:

--- a/lookout/style/format/utils.py
+++ b/lookout/style/format/utils.py
@@ -1,10 +1,56 @@
+"""Commonly used utils."""
 import cProfile
 from functools import wraps
-import pstats
+import glob
 import io
+import pstats
+from typing import Callable, Iterable
+
+from bblfsh import BblfshClient
+from bblfsh.client import NonUTF8ContentException
+from tqdm import tqdm
+
+from lookout.core.api.service_data_pb2 import File
+from lookout.style.format.files_filtering import filter_filepaths
 
 
-def profile(func):
+def prepare_files(folder: str, client: BblfshClient, language: str) -> Iterable[File]:
+    """
+    Prepare the given folder for analysis by extracting UASTs and creating the gRPC wrappers.
+
+    :param folder: Path to the folder to analyze.
+    :param client: Babelfish client. Babelfish server should be started accordingly.
+    :param language: Language to consider. Will discard the other languages
+    :return: Iterator of File-s with content, uast, path and language set.
+    """
+    files = []
+
+    # collect filenames with full path
+    filenames = glob.glob(folder, recursive=True)
+
+    for file in tqdm(filter_filepaths(filenames)):
+        try:
+            res = client.parse(file)
+        except NonUTF8ContentException:
+            # skip files that can't be parsed because of UTF-8 decoding errors.
+            continue
+        if res.status == 0 and res.language.lower() == language.lower():
+            uast = res.uast
+            path = file
+            with open(file) as f:
+                content = f.read().encode("utf-8")
+            files.append(File(content=content, uast=uast, path=path,
+                              language=res.language.lower()))
+    return files
+
+
+def profile(func: Callable) -> Callable:
+    """
+    Profiling decorator.
+
+    :param func: function to be wrapped.
+    :return: wrapped function.
+    """
     @wraps(func)
     def wrapped_profile(*args, **kwargs):
         pr = cProfile.Profile()

--- a/lookout/style/format/utils.py
+++ b/lookout/style/format/utils.py
@@ -1,0 +1,21 @@
+import cProfile
+from functools import wraps
+import pstats
+import io
+
+
+def profile(func):
+    @wraps(func)
+    def wrapped_profile(*args, **kwargs):
+        pr = cProfile.Profile()
+        pr.enable()
+        try:
+            res = func(*args, **kwargs)
+        finally:
+            pr.disable()
+            s = io.StringIO()
+            ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats("cumulative", "time")
+            ps.print_stats(20)
+            print(s.getvalue())
+        return res
+    return wrapped_profile


### PR DESCRIPTION
Depends on https://github.com/src-d/style-analyzer/pull/193
Before:
```
Rule 0: RuleType(attrs=(RuleAttribute(feature=1, cmp=True, threshold=1.5), RuleAttribute(feature=8, cmp=True, threshold=1.0), RuleAttribute(feature=225, cmp=True, threshold=1.0), RuleAttribute(feature=269, cmp=True, threshold=118.0)), stats=RuleStats(cls=8, conf=0.9916667, support=60.0))
Rule 1: RuleType(attrs=(RuleAttribute(feature=1, cmp=True, threshold=1.5), RuleAttribute(feature=8, cmp=True, threshold=1.0), RuleAttribute(feature=225, cmp=True, threshold=1.0), RuleAttribute(feature=269, cmp=False, threshold=118.0), RuleAttribute(feature=269, cmp=True, threshold=114.5)), stats=RuleStats(cls=7, conf=0.9992, support=625.0))
```
After:
```
Rule 0: node_start_col > 1.5 & left_1_keyword_id > 1.0 & left_3_EXPRESSION > 1.0 & left_3_STATEMENT > 118.0 gives class " with confidence 0.9916667 and support 60.0
Rule 1: node_start_col > 1.5 & left_1_keyword_id > 1.0 & left_3_EXPRESSION > 1.0 & left_3_STATEMENT <= 118.0 & left_3_STATEMENT > 114.5 gives class ' with confidence 0.9992 and support 625.0
```

Example of report in details.

<details>

```console
egor@egor-sourced:~/workspace/style-analyzer$ python3 -m lookout.style.format rule -i "/home/egor/workspace/tmp/freeCodeCamp_no_min.js/**/*" -m /tmp/home/egor/workspace/tmp/freeCodeCamp_no_min.js/style.format.analyzer.FormatAnalyzer_1.asdf
/usr/local/lib/python3.5/dist-packages/sklearn/ensemble/weight_boosting.py:29: DeprecationWarning: numpy.core.umath_tests is an internal NumPy module and should not be imported. It will be removed in a future NumPy release.
  from numpy.core.umath_tests import inner1d
Model parameters: {'line_length_limit': 500, 'feature_extractor': {'index_nodes': False, 'insert_noops': False, 'right_siblings_window': 5, 'left_siblings_window': 5, 'node_features': ['start_line', 'start_col'], 'right_features': ['length', 'internal_type', 'reserved', 'roles'], 'parent_features': ['internal_type', 'roles'], 'left_features': ['length', 'diff_offset', 'diff_col', 'diff_line', 'internal_type', 'label', 'reserved', 'roles'], 'selected_features': array([   0,    1,    2,    3,   32,   69,  125,  156,  158,  159,  160,
        163,  166,  168,  171,  193,  202,  212,  214,  217,  218,  226,
        236,  253,  258,  259,  261,  265,  266,  274,  277,  279,  280,
        281,  294,  296,  298,  304,  308,  317,  321,  325,  327,  333,
        334,  339,  340,  351,  358,  362,  374,  379,  380,  381,  394,
        446,  502,  533,  535,  536,  537,  540,  541,  543,  545,  546,
        548,  595,  636,  638,  642,  643,  647,  651,  654,  656,  657,
        658,  664,  665,  671,  673,  675,  679,  681,  682,  694,  698,
        702,  707,  710,  716,  717,  735,  739,  751,  756,  757,  758,
        771,  823,  879,  910,  912,  913,  914,  917,  918,  920,  922,
        925,  966,  980,  990, 1007, 1012, 1019, 1020, 1024, 1028, 1033,
       1034, 1035, 1041, 1048, 1052, 1056, 1058, 1071, 1079, 1081, 1084,
       1087, 1088, 1093, 1094, 1105, 1112, 1116, 1128, 1133, 1134, 1135,
       1148, 1163, 1200, 1256, 1287, 1289, 1290, 1291, 1294, 1297, 1299,
       1302, 1324, 1343, 1349, 1384, 1390, 1392, 1396, 1397, 1401, 1405,
       1408, 1410, 1411, 1412, 1425, 1427, 1429, 1433, 1435, 1436, 1439,
       1448, 1452, 1456, 1458, 1464, 1470, 1471, 1475, 1482, 1489, 1493,
       1505, 1510, 1511, 1512, 1577, 1633, 1664, 1666, 1667, 1668, 1671,
       1672, 1676, 1679, 1701, 1720, 1734, 1736, 1744, 1766, 1769, 1773,
       1774, 1778, 1782, 1787, 1788, 1789, 1795, 1802, 1812, 1813, 1829,
       1833, 1835, 1841, 1847, 1848, 1859, 1870, 1899, 1951, 1988, 2007,
       2038, 2040, 2041, 2043, 2056, 2065, 2079, 2084, 2086, 2089, 2090,
       2098, 2108, 2123, 2131, 2133, 2137, 2141, 2142, 2146, 2149, 2151,
       2152, 2154, 2166, 2168, 2170, 2174, 2176, 2177, 2189, 2193, 2197,
       2199, 2202, 2205, 2206, 2211, 2212, 2216, 2220, 2223, 2230, 2234,
       2246, 2278, 2315, 2352, 2371, 2402, 2404, 2407, 2429, 2448, 2450,
       2453, 2454, 2462, 2464, 2468, 2487, 2494, 2497, 2501, 2502, 2506,
       2510, 2513, 2515, 2516, 2526, 2530, 2532, 2534, 2538, 2540, 2541,
       2544, 2553, 2557, 2561, 2562, 2563, 2566, 2569, 2570, 2575, 2576,
       2580, 2584, 2587, 2594, 2598, 2610, 2642, 2679, 2735, 2766, 2768,
       2771, 2793, 2812, 2817, 2818, 2826, 2836, 2851, 2861, 2865, 2866,
       2874, 2879, 2880, 2902, 2908, 2909, 2917, 2921, 2925, 2933, 2934,
       2939, 2940, 2944, 2951, 2962, 2974, 3006, 3099, 3130, 3132, 3135,
       3176, 3182, 3200, 3229, 3230, 3238, 3244, 3272, 3285, 3291, 3303,
       3308, 3315, 3322, 3326, 3463, 3499, 3540, 3545, 3602, 3622, 3632,
       3645, 3649, 3655, 3661, 3667, 3668, 3672, 3679, 3690, 3708, 3711,
       3712, 3713, 3716, 3718, 3723, 3735, 3762, 3766, 3767, 3772, 3774,
       3798, 3799, 3809, 3812, 3820, 3852, 3858, 3859, 3861, 3862, 3863,
       3865, 3867, 3868, 3869, 3871, 3872, 3876, 3878, 3884, 3885, 3888,
       3891, 3892, 3893, 3894, 3895, 3897, 3901, 3905, 3906, 3907, 3908,
       3916, 3917, 3921, 3923, 3927, 3928, 3942, 3947, 3950, 3955, 3957,
       3962, 3998, 4000, 4001, 4005, 4006, 4037, 4038, 4048, 4050, 4059,
       4063, 4077, 4090, 4091, 4097, 4098, 4100, 4101, 4102, 4106, 4107,
       4108, 4110, 4111, 4115, 4117, 4123, 4124, 4127, 4131, 4132, 4134,
       4136, 4140, 4144, 4145, 4146, 4147, 4155, 4160, 4163, 4164, 4166,
       4167, 4173, 4180, 4181, 4182]), 'remove_constant_features': True, 'parents_depth': 2, 'select_features_number': 500, 'debug_parsing': False, 'no_labels_on_right': True}, 'n_iter': 5, 'n_jobs': -1, 'lower_bound_instances': 500, 'trainable_rules': {'uncertain_attributes': True, 'top_down_greedy_budget': [False, 0.5], 'min_samples_leaf': 9, 'min_samples_split': 5, 'prune_branches_algorithms': ['reduced-error'], 'base_model_name': 'sklearn.tree.DecisionTreeClassifier', 'prune_dataset_ratio': 0.2, 'random_state': 42, 'max_depth': 10, 'prune_attributes': False, 'n_estimators': 10}}
Stats about rules: 64 rules, avg.len. 7.3
Rule 0: node_start_col > 1.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty > 0.5 gives class <+space> with confidence 0.9990512 and support 527
Rule 1: node_start_col > 1.5 & left_0_internal_type_awaitexpression > 8.5 & left_0_internal_type_forstatement > 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_reserved_as > 0.5 gives class <space> with confidence 0.9852941 and support 34
Rule 2: node_start_col > 1.5 & left_0_internal_type_awaitexpression > 8.5 & left_0_internal_type_forstatement > 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_reserved_as <= 0.5 gives class <newline> with confidence 0.992236 and support 322
Rule 3: node_start_col > 1.5 & left_0_internal_type_awaitexpression > 8.5 & left_0_internal_type_forstatement <= 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier > 0.5 gives class ' with confidence 0.97619045 and support 21
Rule 4: node_start_col > 1.5 & left_0_internal_type_awaitexpression > 8.5 & left_0_internal_type_forstatement <= 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 gives class <+space> with confidence 0.8881579 and support 76
Rule 5: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier > 0.5 & left_1_internal_type_declarevariable > 0.5 gives class ' with confidence 0.85294116 and support 17
Rule 6: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_1_internal_type_declarevariable > 0.5 gives class <+space> with confidence 0.928125 and support 160
Rule 7: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_uniontypeannotation > 0.5 & left_1_internal_type_declarevariable <= 0.5 gives class <+space> with confidence 0.9270833 and support 48
Rule 8: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier > 0.5 & left_0_internal_type_uniontypeannotation <= 0.5 & left_1_internal_type_declarevariable <= 0.5 gives class ' with confidence 0.9583333 and support 36
Rule 9: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_internal_type_uniontypeannotation <= 0.5 & left_0_reserved_default > 0.5 & left_1_internal_type_declarevariable <= 0.5 gives class <newline> with confidence 0.97727275 and support 22
Rule 10: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_continuestatement > 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_internal_type_uniontypeannotation <= 0.5 & left_0_reserved_default <= 0.5 & left_1_internal_type_declarevariable <= 0.5 gives class <newline> with confidence 0.96666664 and support 15
Rule 11: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 8.5 & left_0_internal_type_awaitexpression > 4.5 & left_0_internal_type_continuestatement <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectproperty <= 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_internal_type_uniontypeannotation <= 0.5 & left_0_reserved_default <= 0.5 & left_1_internal_type_declarevariable <= 0.5 gives class <space> with confidence 0.9896043 and support 1491
Rule 12: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier > 0.5 gives class ' with confidence 0.9789272 and support 261
Rule 13: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation > 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 gives class <space> with confidence 0.9973262 and support 187
Rule 14: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_" > 0.5 & left_1_internal_type_directive > 0.5 gives class <space> with confidence 0.7380952 and support 21
Rule 15: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_" > 0.5 & left_0_reserved_do > 0.5 & left_1_internal_type_directive <= 0.5 gives class ' with confidence 0.375 and support 12
Rule 16: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_" > 0.5 & left_0_reserved_do <= 0.5 & left_1_internal_type_directive <= 0.5 gives class <newline> with confidence 0.8203884 and support 103
Rule 17: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_emptytypeannotation > 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> > 0.5 & left_0_label_" <= 0.5 gives class <space> with confidence 0.99333334 and support 75
Rule 18: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_emptytypeannotation <= 1.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> > 0.5 & left_0_label_" <= 0.5 gives class ' with confidence 0.7916667 and support 12
Rule 19: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectmethod > 10.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static > 24.5 gives class ' with confidence 0.90384614 and support 26
Rule 20: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_forstatement > 25.0 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectmethod <= 10.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static > 24.5 gives class <newline> with confidence 0.9705882 and support 17
Rule 21: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_forstatement <= 25.0 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_objectmethod <= 10.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static > 24.5 gives class <space> with confidence 0.5735294 and support 34
Rule 22: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_expressionstatement > 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static <= 24.5 gives class ' with confidence 0.94 and support 25
Rule 23: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_expressionstatement <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static <= 24.5 & left_0_reserved_interface > 0.5 gives class <space> with confidence 0.475 and support 20
Rule 24: node_start_col > 1.5 & left_0_internal_type_awaitexpression <= 4.5 & left_0_internal_type_booleanliteraltypeannotation <= 0.5 & left_0_internal_type_expressionstatement <= 0.5 & left_0_internal_type_memberexpression > 0.5 & left_0_internal_type_qualifiedtypeidentifier <= 0.5 & left_0_label_<+tab> <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_static <= 24.5 & left_0_reserved_interface <= 0.5 gives class <+space> with confidence 0.9794521 and support 3431
Rule 25: node_start_col > 1.5 & left_0_internal_type_arrayexpression > 0.5 & left_0_internal_type_interfacedeclaration > 0.5 & left_0_internal_type_memberexpression <= 0.5 gives class ' with confidence 0.99977785 and support 2251
Rule 26: node_start_col > 1.5 & left_0_internal_type_arrayexpression > 0.5 & left_0_internal_type_interfacedeclaration <= 0.5 & left_0_internal_type_interfaceextends > 0.5 & left_0_internal_type_memberexpression <= 0.5 gives class " with confidence 0.9941176 and support 85
Rule 27: node_start_col > 1.5 & left_0_internal_type_arrayexpression > 0.5 & left_0_internal_type_interfacedeclaration <= 0.5 & left_0_internal_type_interfaceextends <= 0.5 & left_0_internal_type_memberexpression <= 0.5 gives class <space> with confidence 0.84375 and support 16
Rule 28: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_classmethod > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_++ > 0.5 & left_0_reserved_( > 20.0 gives class <newline> with confidence 0.98101264 and support 79
Rule 29: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_classmethod > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_++ > 0.5 & left_0_reserved_( <= 20.0 & left_0_reserved_( > 18.5 gives class <space> with confidence 0.8833333 and support 30
Rule 30: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_classmethod > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_++ > 0.5 & left_0_reserved_( <= 18.5 gives class <newline> with confidence 0.88461536 and support 13
Rule 31: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_classmethod > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_++ <= 0.5 gives class <newline> with confidence 0.9931603 and support 2851
Rule 32: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_opaque > 0.5 gives class " with confidence 0.9705882 and support 17
Rule 33: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_opaque <= 0.5 gives class ' with confidence 0.9933036 and support 1120
Rule 34: node_start_col > 60.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_double > 0.5 & left_1_internal_type_file > 0.5 gives class <newline> with confidence 0.96875 and support 16
Rule 35: node_start_col <= 60.5 & node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_double > 0.5 & left_1_internal_type_file > 0.5 gives class <space> with confidence 0.99122804 and support 57
Rule 36: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_withstatement > 0.5 & left_0_reserved_double <= 0.5 & left_1_internal_type_file > 0.5 gives class <space> with confidence 0.98333335 and support 30
Rule 37: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_objecttypeproperty > 0.5 & left_0_internal_type_withstatement <= 0.5 & left_0_reserved_double <= 0.5 & left_1_internal_type_file > 0.5 gives class <space> with confidence 0.8214286 and support 14
Rule 38: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_objecttypeproperty <= 0.5 & left_0_internal_type_withstatement <= 0.5 & left_0_label_" > 0.5 & left_0_reserved_double <= 0.5 & left_1_internal_type_file > 0.5 gives class <space> with confidence 0.8636364 and support 11
Rule 39: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_objecttypeproperty <= 0.5 & left_0_internal_type_withstatement <= 0.5 & left_0_label_" <= 0.5 & left_0_reserved_double <= 0.5 & left_1_internal_type_file > 0.5 gives class <newline> with confidence 0.93499255 and support 1346
Rule 40: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_' > 0.5 & left_1_internal_type_file <= 0.5 gives class <space> with confidence 0.9574074 and support 270
Rule 41: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_regexpliteral > 0.5 & left_0_reserved_' <= 0.5 & left_0_roles_statement > 0.5 & left_1_internal_type_file <= 0.5 gives class <newline> with confidence 0.9736842 and support 57
Rule 42: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_regexpliteral <= 0.5 & left_0_reserved_' <= 0.5 & left_0_roles_statement > 0.5 & left_1_internal_type_file <= 0.5 gives class <space> with confidence 0.75906736 and support 193
Rule 43: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression > 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_' <= 0.5 & left_0_roles_statement <= 0.5 & left_1_internal_type_file <= 0.5 gives class <newline> with confidence 0.9172297 and support 1480
Rule 44: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_do > 0.5 & left_1_internal_type_file <= 0.5 gives class ' with confidence 0.8085554 and support 713
Rule 45: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline > 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_reserved_do <= 0.5 & left_1_internal_type_file <= 0.5 gives class <newline> with confidence 0.9872521 and support 353
Rule 46: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_numbertypeannotation > 0.5 & left_1_internal_type_directive > 0.5 & left_1_internal_type_file <= 0.5 gives class <space> with confidence 0.9137931 and support 87
Rule 47: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_numbertypeannotation > 0.5 & left_1_internal_type_directive <= 0.5 & left_1_internal_type_file <= 0.5 gives class <newline> with confidence 0.827414 and support 901
Rule 48: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_numbertypeannotation <= 0.5 & left_0_reserved_` > 0.5 & left_1_internal_type_file <= 0.5 gives class <newline> with confidence 0.99872124 and support 391
Rule 49: node_start_col > 1.5 & left_0_internal_type_arrayexpression <= 0.5 & left_0_internal_type_arraypattern <= 0.5 & left_0_internal_type_binaryexpression <= 0.5 & left_0_internal_type_classmethod <= 0.5 & left_0_internal_type_commentline <= 0.5 & left_0_internal_type_memberexpression <= 0.5 & left_0_internal_type_numbertypeannotation <= 0.5 & left_0_reserved_` <= 0.5 & left_1_internal_type_file <= 0.5 gives class <space> with confidence 0.82931376 and support 13144
Rule 50: node_start_col <= 1.5 & left_0_internal_type_nullliteraltypeannotation > 0.5 & left_0_reserved_delete > 1.5 & left_0_reserved_class > 0.5 gives class <newline> with confidence 0.5 and support 9
Rule 51: node_start_col <= 1.5 & left_0_internal_type_nullliteraltypeannotation > 0.5 & left_0_reserved_delete > 1.5 & left_0_reserved_class <= 0.5 & left_1_internal_type_existstypeannotation > 0.5 gives class <+space> with confidence 0.5769231 and support 13
Rule 52: node_start_col <= 1.5 & node_start_line > 39.0 & left_0_internal_type_nullliteraltypeannotation > 0.5 & left_0_reserved_delete > 1.5 & left_0_reserved_class <= 0.5 & left_1_internal_type_existstypeannotation <= 0.5 & left_1_internal_type_nullliteral > 0.5 gives class <newline> with confidence 0.5 and support 9
Rule 53: node_start_col <= 1.5 & node_start_line <= 39.0 & left_0_internal_type_nullliteraltypeannotation > 0.5 & left_0_reserved_delete > 1.5 & left_0_reserved_class <= 0.5 & left_1_internal_type_existstypeannotation <= 0.5 & left_1_internal_type_nullliteral > 0.5 gives class <+space> with confidence 0.96666664 and support 15
Rule 54: node_start_col <= 1.5 & left_0_internal_type_nullliteraltypeannotation > 0.5 & left_0_reserved_delete > 1.5 & left_0_reserved_class <= 0.5 & left_1_internal_type_existstypeannotation <= 0.5 & left_1_internal_type_nullliteral <= 0.5 gives class <+space> with confidence 0.9734042 and support 282
Rule 55: node_start_col <= 1.5 & left_0_internal_type_assignmentexpression > 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 gives class <-space> with confidence 0.99545455 and support 110
Rule 56: node_start_col <= 1.5 & left_0_internal_type_assignmentexpression <= 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 & left_1_internal_type_classbody > 0.5 gives class <+space> with confidence 0.9444444 and support 63
Rule 57: node_start_col <= 1.5 & left_0_diff_col > 0.5 & left_0_internal_type_assignmentexpression <= 0.5 & left_0_internal_type_exportspecifier > 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 & left_1_internal_type_classbody <= 0.5 gives class <newline> with confidence 0.625 and support 20
Rule 58: node_start_col <= 1.5 & left_0_diff_col <= 0.5 & left_0_internal_type_assignmentexpression <= 0.5 & left_0_internal_type_exportspecifier > 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 & left_1_internal_type_classbody <= 0.5 gives class <-space> with confidence 0.98275864 and support 29
Rule 59: node_start_col <= 1.5 & left_0_internal_type_assignmentexpression <= 0.5 & left_0_internal_type_exportspecifier <= 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 & left_1_internal_type_classbody <= 0.5 & left_1_internal_type_directive > 0.5 gives class <+space> with confidence 0.65625 and support 16
Rule 60: node_start_col <= 1.5 & left_0_internal_type_assignmentexpression <= 0.5 & left_0_internal_type_exportspecifier <= 0.5 & left_0_internal_type_nullliteraltypeannotation <= 0.5 & left_0_reserved_delete > 1.5 & left_1_internal_type_classbody <= 0.5 & left_1_internal_type_directive <= 0.5 gives class <newline> with confidence 0.93640125 and support 967
Rule 61: node_start_col <= 1.5 & left_0_reserved_delete <= 1.5 & left_0_reserved_= > 0.5 gives class <newline> with confidence 0.54310346 and support 58
Rule 62: node_start_col <= 1.5 & left_0_internal_type_inferredpredicate > 0.5 & left_0_reserved_delete <= 1.5 & left_0_reserved_= <= 0.5 gives class <+space> with confidence 0.95 and support 10
Rule 63: node_start_col <= 1.5 & left_0_internal_type_inferredpredicate <= 0.5 & left_0_reserved_delete <= 1.5 & left_0_reserved_= <= 0.5 gives class <-space> with confidence 0.9932686 and support 4531
Min/max support: 9/13144, min/max conf: 0.375/0.99977785
443it [00:03, 112.24it/s]
Number of files: 177
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 48341/48341 [00:00<00:00, 1081923.81it/s]
Overall statistics:
Legend: predictions/ground truth
#rule           |<space>    |<tab>|<newline>|<+space> |<-space> |<+tab>|<-tab>|'        |"      |<noop>|n_mistakes|support
Rule number 0:  |0/0        |0/0  |0/0      |675/675  |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |675    
Rule number 1:  |40/40      |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |40     
Rule number 2:  |0/4        |0/0  |386/382  |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |4         |386    
Rule number 3:  |0/0        |0/0  |0/0      |0/1      |0/0      |0/0   |0/0   |28/27    |0/0    |0/0   |1         |28     
Rule number 4:  |0/2        |0/0  |0/0      |94/84    |0/0      |0/0   |0/0   |0/8      |0/0    |0/0   |10        |94     
Rule number 5:  |0/0        |0/0  |0/0      |0/2      |0/0      |0/0   |0/0   |22/20    |0/0    |0/0   |2         |22     
Rule number 6:  |0/6        |0/0  |0/6      |208/195  |0/0      |0/0   |0/0   |0/1      |0/0    |0/0   |13        |208    
Rule number 7:  |0/0        |0/0  |0/0      |60/57    |0/0      |0/0   |0/0   |0/2      |0/1    |0/0   |3         |60     
Rule number 8:  |0/0        |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |44/43    |0/1    |0/0   |1         |44     
Rule number 9:  |0/0        |0/0  |31/31    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |31     
Rule number 10: |0/1        |0/0  |20/19    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |1         |20     
Rule number 11: |1821/1801  |0/0  |0/4      |0/15     |0/0      |0/0   |0/0   |0/1      |0/0    |0/0   |20        |1821   
Rule number 12: |0/0        |0/0  |0/0      |0/6      |0/0      |0/0   |0/0   |327/321  |0/0    |0/0   |6         |327    
Rule number 13: |234/234    |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |234    
Rule number 14: |26/20      |0/0  |0/5      |0/1      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |6         |26     
Rule number 15: |0/4        |0/0  |0/2      |0/3      |0/0      |0/0   |0/0   |15/6     |0/0    |0/0   |9         |15     
Rule number 16: |0/19       |0/0  |138/115  |0/4      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |23        |138    
Rule number 17: |102/102    |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |102    
Rule number 18: |0/0        |0/0  |0/1      |0/2      |0/0      |0/0   |0/0   |14/11    |0/0    |0/0   |3         |14     
Rule number 19: |0/0        |0/0  |0/0      |0/3      |0/0      |0/0   |0/0   |34/31    |0/0    |0/0   |3         |34     
Rule number 20: |0/0        |0/0  |22/22    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |22     
Rule number 21: |41/25      |0/0  |0/7      |0/9      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |16        |41     
Rule number 22: |0/0        |0/0  |0/0      |0/1      |0/0      |0/0   |0/0   |33/31    |0/1    |0/0   |2         |33     
Rule number 23: |26/13      |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/13     |0/0    |0/0   |13        |26     
Rule number 24: |0/49       |0/0  |0/19     |4304/4207|0/0      |0/0   |0/0   |0/29     |0/0    |0/0   |97        |4304   
Rule number 25: |0/0        |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |2836/2836|0/0    |0/0   |0         |2836   
Rule number 26: |0/0        |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |108/108|0/0   |0         |108    
Rule number 27: |19/16      |0/0  |0/3      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |3         |19     
Rule number 28: |0/1        |0/0  |96/95    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |1         |96     
Rule number 29: |34/31      |0/0  |0/3      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |3         |34     
Rule number 30: |0/1        |0/0  |14/13    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |1         |14     
Rule number 31: |0/29       |0/0  |3543/3514|0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |29        |3543   
Rule number 32: |0/0        |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |21/21  |0/0   |0         |21     
Rule number 33: |0/0        |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |1384/1377|0/7    |0/0   |7         |1384   
Rule number 34: |0/0        |0/0  |20/20    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |20     
Rule number 35: |71/71      |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |71     
Rule number 36: |38/38      |0/0  |0/0      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |38     
Rule number 37: |17/15      |0/0  |0/2      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |2         |17     
Rule number 38: |14/13      |0/0  |0/1      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |1         |14     
Rule number 39: |0/113      |0/0  |1682/1569|0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |113       |1682   
Rule number 40: |346/332    |0/0  |0/14     |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |14        |346    
Rule number 41: |0/3        |0/0  |71/68    |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |3         |71     
Rule number 42: |255/192    |0/0  |0/63     |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |63        |255    
Rule number 43: |0/156      |0/0  |1846/1690|0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |156       |1846   
Rule number 44: |0/0        |0/0  |0/96     |0/0      |0/0      |0/0   |0/0   |905/737  |0/72   |0/0   |168       |905    
Rule number 45: |0/1        |0/0  |430/426  |0/0      |0/0      |0/0   |0/0   |0/3      |0/0    |0/0   |4         |430    
Rule number 46: |104/97     |0/0  |0/7      |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |7         |104    
Rule number 47: |0/196      |0/0  |1092/896 |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |196       |1092   
Rule number 48: |0/0        |0/0  |488/488  |0/0      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |488    
Rule number 49: |16477/13675|0/0  |0/2557   |0/55     |0/0      |0/0   |0/0   |0/185    |0/5    |0/0   |2802      |16477  
Rule number 50: |0/0        |0/0  |11/5     |0/6      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |6         |11     
Rule number 51: |0/0        |0/0  |0/5      |15/9     |0/1      |0/0   |0/0   |0/0      |0/0    |0/0   |6         |15     
Rule number 52: |0/0        |0/0  |12/7     |0/5      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |5         |12     
Rule number 53: |0/0        |0/0  |0/0      |18/18    |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |18     
Rule number 54: |0/0        |0/0  |0/8      |361/352  |0/0      |0/0   |0/0   |0/1      |0/0    |0/0   |9         |361    
Rule number 55: |0/0        |0/0  |0/0      |0/0      |134/134  |0/0   |0/0   |0/0      |0/0    |0/0   |0         |134    
Rule number 56: |0/0        |0/0  |0/2      |74/71    |0/1      |0/0   |0/0   |0/0      |0/0    |0/0   |3         |74     
Rule number 57: |0/0        |0/0  |25/16    |0/9      |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |9         |25     
Rule number 58: |0/0        |0/0  |0/0      |0/0      |38/38    |0/0   |0/0   |0/0      |0/0    |0/0   |0         |38     
Rule number 59: |0/0        |0/0  |0/7      |24/17    |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |7         |24     
Rule number 60: |0/0        |0/0  |1237/1159|0/4      |0/69     |0/0   |0/0   |0/5      |0/0    |0/0   |78        |1237   
Rule number 61: |0/0        |0/0  |72/45    |0/27     |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |27        |72     
Rule number 62: |0/0        |0/0  |0/0      |11/11    |0/0      |0/0   |0/0   |0/0      |0/0    |0/0   |0         |11     
Rule number 63: |0/0        |0/0  |0/23     |0/12     |5653/5618|0/0   |0/0   |0/0      |0/0    |0/0   |35        |5653   
         632189658 function calls (632178687 primitive calls) in 153.015 seconds

   Ordered by: cumulative time, internal time
   List reduced from 1271 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.050    0.050  153.104  153.104 rule_stat.py:71(print_rules_report)
        1    0.032    0.032  128.071  128.071 feature_extractor.py:133(extract_features)
      177    1.758    0.010  124.744    0.705 feature_extractor.py:414(_inplace_write_vnode_features)
   618080   10.121    0.000  121.628    0.000 feature_extractor.py:398(_inplace_write_features)
   618080   40.510    0.000  111.385    0.000 feature_extractor.py:410(<listcomp>)
199822292   28.809    0.000   46.583    0.000 feature_extractor.py:362(_get_features)
199925544   24.469    0.000   24.469    0.000 {built-in method builtins.min}
        1    0.126    0.126   20.476   20.476 rules.py:72(predict)
    48341   13.800    0.000   20.344    0.000 rules.py:144(_compute_triggered)
  2655122    1.282    0.000    6.334    0.000 fromnumeric.py:1104(searchsorted)
 86600328    5.919    0.000    6.170    0.000 features.py:206(__call__)
 50706771    4.475    0.000    5.405    0.000 features.py:261(__call__)
  2703463    1.001    0.000    5.121    0.000 fromnumeric.py:49(_wrapfunc)
 59816750    3.997    0.000    4.044    0.000 features.py:243(__call__)
        1    0.200    0.200    3.961    3.961 quality_report.py:20(prepare_files)
  2655122    3.782    0.000    3.782    0.000 {method 'searchsorted' of 'numpy.ndarray' objects}
      443    0.009    0.000    3.670    0.008 client.py:51(parse)
      443    0.002    0.000    3.648    0.008 _channel.py:512(__call__)
      443    0.003    0.000    3.645    0.008 _channel.py:496(_blocking)
      443    3.431    0.008    3.438    0.008 {method 'next_event' of 'grpc._cython.cygrpc.SegregatedCall' objects}
```

</details>