### PR TITLE
Pretty comment message for debugging

### DIFF
--- a/lookout/style/format/descriptions.py
+++ b/lookout/style/format/descriptions.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from copy import copy
 from functools import singledispatch
 from math import ceil, floor
-from typing import List, Tuple
+from typing import List, Optional, Tuple, Sequence
 
 from numpy import flatnonzero, floating, ndarray
 
@@ -11,6 +11,7 @@ from lookout.style.format.feature_extractor import FeatureExtractor, FEATURES_MA
 from lookout.style.format.feature_utils import (
     CLASS_INDEX, CLASSES, CLS_DOUBLE_QUOTE, CLS_NEWLINE, CLS_NOOP, CLS_SINGLE_QUOTE, CLS_SPACE,
     CLS_SPACE_DEC, CLS_SPACE_INC, CLS_TAB, CLS_TAB_DEC, CLS_TAB_INC)
+from lookout.style.format.feature_utils import VirtualNode
 from lookout.style.format.features import BagFeature, CategoricalFeature, OrdinalFeature
 from lookout.style.format.rules import Rule
 
@@ -184,3 +185,49 @@ def describe_rule_parts_ordinal(feature: OrdinalFeature, name: str,
     """
     cmp, threshold, _ = splits[0]
     return _format_int(cmp, threshold, name)
+
+
+def get_error_description(vnode: VirtualNode, y_pred: int) -> str:
+    """
+    Return the comment with regard to the correct node class.
+
+    :param vnode: Node to describe.
+    :param y_pred: The index of the correct node class.
+    :return: String comment.
+    """
+    column = vnode.start.col
+    if y_pred == CLASS_INDEX[CLS_NOOP]:
+        return "%s at column %d should be removed." % (CLASS_REPRESENTATIONS[vnode.y], column)
+    if vnode.y == CLASS_INDEX[CLS_NOOP]:
+        return "%s should be inserted at column %d." % (CLASS_REPRESENTATIONS[y_pred], column)
+    return "Replace %s with %s at column %d." % (
+        CLASS_REPRESENTATIONS[vnode.y], CLASS_REPRESENTATIONS[y_pred], column)
+
+
+def get_code_chunk(lang: str, code_lines: Sequence[str], line_number: int) -> str:
+    """
+    Return nice code snippet that can be inserted to github message.
+
+    :param lang: Code language. Both styles `javascript` and `JavaScript` are suitable.
+    :param code_lines: Sequence of code lines without ending new line character.
+    :param line_number: 1-based line number to print.
+    :return: Code snippet.
+    """
+    lines = list(range(max(0, line_number - 2), line_number + 1))
+    code_chunk = "\n".join("%d|%s" % (l, code_lines[l]) for l in lines)
+    return "```%s\n%s\n```\n" % (lang, code_chunk)
+
+
+def rule_to_comment(rule: Rule, feature_extractor: FeatureExtractor, number: Optional[int]=None
+                    ) -> str:
+    """
+    Return the comment for the rule.
+
+    :param rule: The rule to convert to string.
+    :param number: Triggered rule number if applicable.
+    :param feature_extractor: Corresponding feature extractor.
+    :return: String comment.
+    """
+    number = "<NA>" if number is None else str(number)
+    return "Triggered rule # %s:\n```\n\t%s\n```" % (
+        number, describe_rule(rule, feature_extractor))

--- a/lookout/style/format/feature_utils.py
+++ b/lookout/style/format/feature_utils.py
@@ -2,7 +2,6 @@ from typing import Callable, Iterable, Mapping, NamedTuple, Tuple
 
 import bblfsh
 
-from lookout.core.api.service_analyzer_pb2 import Comment
 
 Position = NamedTuple("Position", (("offset", int), ("line", int), ("col", int)))
 """
@@ -112,26 +111,6 @@ class VirtualNode:
                                        line=node.end_position.line,
                                        col=node.end_position.col),
                               path=path)
-
-    def to_comment(self, correct_y: int) -> Comment:
-        """
-        Writes the comment with regard to the correct node class.
-        :param correct_y: the index of the correct node class.
-        :return: Lookout Comment object.
-        """
-        comment = Comment()
-        comment.line = self.start.line
-        if correct_y == CLASS_INDEX[CLS_NOOP]:
-            comment.text = "format: %s at column %d should be removed" % (
-                CLASSES[self.y], self.start.col)
-        elif self.y == CLASS_INDEX[CLS_NOOP]:
-            comment.text = "format: %s should be inserted at column %d" % (
-                CLASSES[correct_y], self.start.col)
-        else:
-            comment.text = "format: replace %s with %s at column %d" % (
-                CLASSES[self.y], CLASSES[correct_y], self.start.col)
-        comment.text = comment.text.replace("<", "`").replace(">", "`")
-        return comment
 
 
 CLS_SPACE = "<space>"


### PR DESCRIPTION
Ability to get comments like this:

----
format: style mismatch:
```javascript
17|function getCompletedCertCount(user) {
18|  return
19|  [
```
Replace `<newline>` with `<space>` at column 9.
Confidence: 0.896
Triggered rule # 65:
```
    left_2_reserved in |.|
    left_1_label in |<newline>|
    left_0_reserved in |;˙{˙}|
    left_0_label in |<+space>˙<-space>˙<newline>|
    left_2_roles in |string|
    left_0_roles in |string|
```
----

This code requires more work and some refactoring. But it is hard to do in one PR at once. 
So I left todos there. It is better to start from something at least.