### PR TITLE
Match CLASSES order when declaring individual classes in feature_utils

### DIFF
--- a/lookout/style/format/feature_utils.py
+++ b/lookout/style/format/feature_utils.py
@@ -42,7 +42,7 @@ class VirtualNode:
 
     def __repr__(self) -> str:
         return ("VirtualNode(\"%s\", y=%s, start=%s, end=%s, node=%s, path=\"%s\", "
-                "global_index=%d, labeled_index=%d)" % (
+                "global_index=%s, labeled_index=%s)" % (
                     self.value.replace("\n", "\\n"),
                     "None" if self.y is None else self.y,
                     tuple(self.start),

--- a/lookout/style/format/feature_utils.py
+++ b/lookout/style/format/feature_utils.py
@@ -144,12 +144,12 @@ class VirtualNode:
 
 
 CLS_SPACE = "<space>"
+CLS_TAB = "<tab>"
+CLS_NEWLINE = "<newline>"
 CLS_SPACE_INC = "<+space>"
 CLS_SPACE_DEC = "<-space>"
-CLS_TAB = "<tab>"
 CLS_TAB_INC = "<+tab>"
 CLS_TAB_DEC = "<-tab>"
-CLS_NEWLINE = "<newline>"
 CLS_SINGLE_QUOTE = "'"
 CLS_DOUBLE_QUOTE = '"'
 CLS_NOOP = "<noop>"


### PR DESCRIPTION
1st commit fixes a bug in the repr method of VirtualNode that causes TypeErrors when extracting the features
2nd commit is just to avoid confusion reading the classes and their corresponding indices