### PR TITLE
Switch order for pylint and flake documentation checks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 check:
 	flake8 --config .flake8-code .
-	pylint lookout
 	flake8 --config .flake8-doc .
+	pylint lookout
 
 .PHONY: check


### PR DESCRIPTION
pylint takes a long time, so I want to ctrl+C it sometimes.
Signed-off-by: Konstantin Slavnov <kslavnov@gmail.com>