### PR TITLE
Fix setup and Dockerfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
+import os
 from importlib.machinery import SourceFileLoader
 
 from setuptools import find_packages, setup
 
 lookout = SourceFileLoader("lookout", "./lookout/__init__.py").load_module()
 
-with open("README.md") as f:
+with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
     long_description = f.read()
 
 tests_require = ["docker>=3.4.0,<4.0"]


### PR DESCRIPTION
Setup unable to find `README.md` because it runs from another directory.

See also: https://hub.docker.com/r/srcd/style-analyzer/builds/