### PR TITLE
Fix print_usage

### DIFF
--- a/lookout/style/format/__main__.py
+++ b/lookout/style/format/__main__.py
@@ -103,7 +103,7 @@ def main() -> Any:
         handler = args.handler
         delattr(args, "handler")
     except AttributeError:
-        def print_usage(_):
+        def print_usage(*args, **kwargs):
             parser.print_usage()
 
         handler = print_usage


### PR DESCRIPTION
before:
```
➜  style-analyzer git:(fix/print_usage) python3 -m lookout.style.format               
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/k/sourced/workdir/style-analyzer/lookout/style/format/__main__.py", line 114, in <module>
    sys.exit(main())
  File "/home/k/sourced/workdir/style-analyzer/lookout/style/format/__main__.py", line 110, in main
    return handler(**vars(args))
TypeError: print_usage() missing 1 required positional argument: '_'
```
after:
```
➜  style-analyzer git:(fix/print_usage) python3 -m lookout.style.format
usage: __main__.py [-h] [--log-level LOG_LEVEL]
                   {eval,vis,rule,robust-eval} ...

```