### PR TITLE
Add delete line surroundings to analyze

### DIFF
--- a/lookout/core/lib.py
+++ b/lookout/core/lib.py
@@ -27,6 +27,27 @@ def find_new_lines(before: File, after: File) -> List[int]:
     return result
 
 
+def find_deleted_lines(before: File, after: File) -> List[int]:
+    """
+    Return line numbers next to deleted lines in the new file.
+
+    :param before: the previous contents of the file.
+    :param after: the new contents of the file.
+    :return: list of line numbers next to deleted lines.
+    """
+    before_lines = before.content.decode("utf-8", "replace").splitlines()
+    after_lines = after.content.decode("utf-8", "replace").splitlines()
+    matcher = SequenceMatcher(a=before_lines, b=after_lines)
+    result = []
+    for action, _, _, j1, _ in matcher.get_opcodes():
+        if action == "delete":
+            if j1 != 0:
+                result.append(j1)
+            if j1 != len(after_lines):
+                result.append(j1 + 1)
+    return result
+
+
 def extract_changed_nodes(root: Node, lines: Sequence[int]) -> List[Node]:
     """
     Collect the list of UAST nodes which lie on the changed lines.

--- a/lookout/core/tests/test_lib.py
+++ b/lookout/core/tests/test_lib.py
@@ -3,11 +3,51 @@ import unittest
 from bblfsh import Node, Position
 
 from lookout.core.api.service_data_pb2 import File
-from lookout.core.lib import extract_changed_nodes, files_by_language, filter_files, find_new_lines
+from lookout.core.lib import (
+    extract_changed_nodes, files_by_language, filter_files, find_deleted_lines, find_new_lines)
 
 
 class LibTests(unittest.TestCase):
-    def test_diff(self):
+    def test_find_deleted_lines(self):
+        text_base = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Maecenas volutpat dui id ipsum cursus, sit amet accumsan nisl ornare.
+        Vivamus euismod lorem viverra semper dictum.
+        Nam consectetur enim eget elementum mattis.
+        Ut condimentum metus vehicula tellus tempus, vel ultricies lectus dapibus.
+        Etiam vitae nisi at ante pretium lacinia et eu massa."""
+        base_lines_number = text_base.count("\n") + 1
+        # Delete first line
+        new_line_indices = find_deleted_lines(
+            File(content=bytes(text_base, "utf-8")),
+            File(content=bytes("\n".join(text_base.split("\n")[1:]), "utf-8")))
+        self.assertEqual(new_line_indices, [1])
+        # Delete first two lines
+        new_line_indices = find_deleted_lines(
+            File(content=bytes(text_base, "utf-8")),
+            File(content=bytes("\n".join(text_base.split("\n")[2:]), "utf-8")))
+        self.assertEqual(new_line_indices, [1])
+        # Delete last line
+        new_line_indices = find_deleted_lines(
+            File(content=bytes(text_base, "utf-8")),
+            File(content=bytes("\n".join(text_base.split("\n")[:-1]), "utf-8")))
+        self.assertEqual(new_line_indices, [base_lines_number - 1])
+        # Delete last two lines
+        new_line_indices = find_deleted_lines(
+            File(content=bytes(text_base, "utf-8")),
+            File(content=bytes("\n".join(text_base.split("\n")[:-2]), "utf-8")))
+        self.assertEqual(new_line_indices, [base_lines_number - 2])
+        # Delete line in the middle
+        middle = 3
+        text_head = text_base.split("\n")
+        text_head.pop(middle)
+        text_head = "\n".join(text_head)
+        new_line_indices = find_deleted_lines(
+            File(content=bytes(text_base, "utf-8")),
+            File(content=bytes(text_head, "utf-8")))
+        self.assertEqual(new_line_indices, [middle, middle + 1])
+
+    def test_find_modified_lines(self):
         text_base = """
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         Maecenas volutpat dui id ipsum cursus, sit amet accumsan nisl ornare.


### PR DESCRIPTION
Imagine the situation:
We have this code in base commit:
```python
class A:
    pass


class B:
    pass
```
And bad-style head commit suggests us delete one newline:
```python
class A:
    pass

class B:
    pass
```
We see only one deletion in the diff and ignore it now (that how `find_new_lines` works). So style analyzer gives No feedback.
I suggest to include one line before deletion and one line after. 

Also I rename `find_new_lines` to `find_modified_lines` for better understanding what the function do.