### PR TITLE
Move __version__ to style submodule

### DIFF
--- a/lookout/__init__.py
+++ b/lookout/__init__.py
@@ -2,4 +2,3 @@
 # DO NOT CHANGE OR ADD ANYTHING HERE
 import pkg_resources
 pkg_resources.declare_namespace(__name__)
-__version__ = 0, 0, 3

--- a/lookout/core/__init__.py
+++ b/lookout/core/__init__.py
@@ -1,0 +1,4 @@
+# This is version for further lookout-core python package.
+# It should be used after core+format splitting and this comment should be deleted.
+# If you want to bump version now go to lookout.style.__init__.__version__
+__version__ = 0, 0, 1

--- a/lookout/style/__init__.py
+++ b/lookout/style/__init__.py
@@ -1,2 +1,3 @@
 """Supported machine learning based analyzers for lookout."""
+__version__ = 0, 0, 3
 __meta__ = True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 from setuptools import find_packages, setup
 
-lookout = SourceFileLoader("lookout", "./lookout/__init__.py").load_module()
+lookout_style = SourceFileLoader("lookout", "./lookout/style/__init__.py").load_module()
 
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:
     long_description = f.read()
@@ -15,7 +15,7 @@ setup(
     description="Machine learning-based assisted code review - code style analyzers.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version=".".join(map(str, lookout.__version__)),
+    version=".".join(map(str, lookout_style.__version__)),
     license="AGPL-3.0",
     author="source{d}",
     author_email="machine-learning@sourced.tech",


### PR DESCRIPTION
As was discussed this `__version__` related to style-analyzer part and for the lookout-core part will be another package and module( see issue https://github.com/src-d/style-analyzer/issues/266)