### PR TITLE
Add release to Helm and Docker hub using src-d/ci

### DIFF
--- a/.helm_staging.yml
+++ b/.helm_staging.yml
@@ -1,0 +1,12 @@
+app:
+  dataServiceUrl: ipv4://lookout:10301
+
+databases:
+  postgres:
+    cloudSQL: true
+    instanceConnectionName: srcd-public-staging:europe-west1:lookout-staging-primary
+    serviceAccountSecret: cloudsql-proxy-credentials
+    connectionDetailsSecret: lookout-postgres-connection-details
+
+nodeSelector:
+  srcd.host/app: lookout

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,14 @@ matrix:
       script:
         - python3 setup.py bdist_wheel
       deploy: *_deploy
+    - name: 'Push image to Docker Hub'
+      stage: deploy
+      script:
+        - DOCKER_PUSH_LATEST=true make docker-push
+    - name: 'Deploy to staging'
+      stage: deploy
+      script:
+        - HELM_RELEASE=lookout-style-analyzer HELM_CHART=src-d/lookout-style-analyzer K8S_NAMESPACE=lookout HELM_ARGS="--tiller-namespace=lookout --set image.tag=$TRAVIS_TAG -f .helm_staging.yml" make deploy
   fast_finish: true
 before_script:
   - docker run -d --privileged -p 9432:9432 --name bblfshd bblfsh/bblfshd

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 current_dir = $(shell pwd)
 
+PROJECT = style-analyzer
+
+DOCKERFILES = Dockerfile:$(PROJECT)
+DOCKER_ORG = "srcd"
+
+# Including ci Makefile
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
+CI_PATH ?= .ci
+MAKEFILE := $(CI_PATH)/Makefile.main
+$(MAKEFILE):
+	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
+-include $(MAKEFILE)
+
+
 .PHONY: check
 check:
 	flake8 --config .flake8-code . --count


### PR DESCRIPTION
This will replace the docker hub builds by a Travis release that will also update the deployment in lookout staging.

This still needs the Docker credentials in Travis CI (which I don't have yet) cc @rporres 