### PR TITLE
Add proper error report for bad configs

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -295,5 +295,10 @@ class FormatAnalyzer(Analyzer):
         }
         config = merge_dicts(defaults, config)
         global_config = config.pop("global")
-        return {lang: merge_dicts(global_config, lang_config)
-                for lang, lang_config in config.items()}
+        try:
+            return {lang: merge_dicts(global_config, lang_config)
+                    for lang, lang_config in config.items()}
+        except AttributeError as e:
+            raise ValueError("Config %s can not be merged with default values config: %s" % (
+                config, global_config
+            ))


### PR DESCRIPTION
`AttributeError` happens if you try to merge incompatible dicts like:
```python
dict1 = dict(
    b=dict(c=0)
)
dict2 = dict(
    b = 0
)
merge_dicts(dict1, dict2)  # raises AttributeError
```

This PR gives proper error message that helps to understand what to fix.