### PR TITLE
Optimize Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache: pip
 before_cache:
   - chown -R travis:travis $HOME/.cache/pip
 stages:
+  - style
   - test
   - name: deploy
     # require any tag name to deploy
@@ -33,24 +34,21 @@ _deploy: &_deploy
     tags: true
 matrix:
   include:
-    - python: 3.5
-      env: *_coverage
-      install: *_install
-    - python: 3.6
-      env: *_coverage
-      install: *_install
-    - python: 3.7
-      env: SCRIPT="flake8 . --config .flake8-code
-                   && pylint lookout
-                   && flake8 . --config .flake8-doc
-                   && (! grep -R /tmp lookout/style/*/tests)
+    - stage: style
+      python: 3.7
+      env: SCRIPT="make check
                    && rm -rf lookout/core/server
                    && cd doc && make
                    && cd ../lookout/style/format/visualizer && npm run build"
       install:
         - pip install -r doc/requirements.txt -r requirements-lint.txt
         - cd lookout/style/format/visualizer && npm install && cd -
+    - stage: test
+      python: 3.5
+      env: *_coverage
+      install: *_install
     - python: 3.6
+      # We test python 3.6 inside docker.
       env: SCRIPT="make docker-build && make docker-test"
     - python: 3.7
       env: *_coverage

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ current_dir = $(shell pwd)
 
 .PHONY: check
 check:
+	! grep -R /tmp lookout/style/*/tests
 	flake8 --config .flake8-code . --count
 	flake8 --config .flake8-doc . --count
 	pylint lookout


### PR DESCRIPTION
So, what I did:
- Add one more stage called `style`: It lasts around 3 mins and saves us one Travis slot. 
- Exclude python 3.6 check because we check it inside docker, so it was a double job. +1 more Travis slot.
- Use `make check` in Travis.