### PR TITLE
Remove dco.yml

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
As I get it we decide that source{d} members should always sign-off PRs.