### PR TITLE
Add --rm flag to make bblfsh-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ docker-test:
 .PHONY: bblfsh-start
 bblfsh-start:
 	! docker ps | grep bblfshd # bblfsh server has been run already.
-	docker run -d --name style_analyzer_bblfshd --privileged -p 9432\:9432 bblfsh/bblfshd\:v2.5.0
+	docker run -d --rm --name style_analyzer_bblfshd --privileged -p 9432\:9432 \
+		bblfsh/bblfshd\:v2.5.0
 	docker exec style_analyzer_bblfshd bblfshctl driver install \
 		javascript docker://bblfsh/javascript-driver\:v1.2.0


### PR DESCRIPTION
It is possible to use both flags `-d` and `--rm` (https://github.com/moby/moby/issues/10545#issuecomment-354560625) since v1.13. Let's use it because it is so much convenient.