### PR TITLE
Fix for missing multiline VirtualNodes

### DIFF
--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -262,8 +262,7 @@ class FeatureExtractor:
             parsed_files.append((file_vnodes, file_parents, file_lines))
 
         labels = [[self.class_sequences_to_labels[vnode.y]
-                   for vnode in file_vnodes if vnode.y is not None and (
-                       vnode.start.line in file_lines if file_lines is not None else True)]
+                   for vnode in file_vnodes if vnode.is_labeled_on_lines(file_lines)]
                   for file_vnodes, file_parents, file_lines in parsed_files]
 
         if not labels:
@@ -598,7 +597,7 @@ class FeatureExtractor:
         for i, vnode in enumerate(vnodes):
             if vnode.node:
                 closest_left_node_id = id(vnode.node)
-            if vnode.y is None or (lines is not None and vnode.start.line not in lines):
+            if not vnode.is_labeled_on_lines(lines):
                 continue
             if self.parents_depth:
                 parent = self._find_parent(i, vnodes, parents, closest_left_node_id)

--- a/lookout/style/format/feature_utils.py
+++ b/lookout/style/format/feature_utils.py
@@ -1,5 +1,5 @@
 """Facilities to create and use features."""
-from typing import Callable, Iterable, Mapping, NamedTuple, Tuple, Union
+from typing import Callable, Iterable, Mapping, NamedTuple, Optional, Set, Tuple, Union
 
 import bblfsh
 
@@ -60,6 +60,17 @@ class VirtualNode:
                 and self.node == other.node
                 and self.y == other.y
                 and self.path == other.path)
+
+    def is_labeled_on_lines(self, lines: Optional[Set[int]]) -> bool:
+        """
+        Return true for labeled VirtualNode instance that located on specified lines.
+
+        :param lines: list of lines or None. None is considered as all possible lines.
+        :return: Condition value
+        """
+        if self.y is None:
+            return False
+        return lines is None or bool(lines.intersection(range(self.start.line, self.end.line + 1)))
 
     @staticmethod
     def from_node(node: bblfsh.Node, file: str, path: str,


### PR DESCRIPTION
Example:
```python
vnode.start.line = 10
vnode.end.line = 13

file_lines = [11]
```
Checking `vnode.start.line in file_lines` is not enough in this case, so we miss this VirtualNode before. 