### PR TITLE
Add CD to project

### DIFF
--- a/.helm_staging.yml
+++ b/.helm_staging.yml
@@ -1,0 +1,16 @@
+app:
+  requestServer: lookout-work:10301
+  log:
+    level: DEBUG
+  volume:
+    pvcName: lookout-style-analyzer
+
+databases:
+  postgres:
+    cloudSQL: true
+    instanceConnectionName: srcd-public-staging:europe-west1:lookout-staging-primary
+    serviceAccountSecret: cloudsql-proxy-credentials
+    connectionDetailsSecret: lookout-style-analyzer-postgres-connection-details
+
+nodeSelector:
+  srcd.host/app: lookout

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ stages:
   - name: deploy
     # require any tag name to deploy
     if: tag =~ .*
+  - name: deploy-k8s
+    if: tag =~ .*
 _install: &_install
   - pip install --upgrade pip cython codecov
   - pip install -e .[test,plot]
@@ -64,6 +66,18 @@ matrix:
       script:
         - python3 setup.py bdist_wheel
       deploy: *_deploy
+    - name: 'Push image to Docker Hub'
+      python: 3.5
+      stage: deploy
+      script:
+        - DOCKER_PUSH_LATEST=true make docker-push
+    - name: 'Deploy to staging'
+      stage: deploy-k8s
+      python: 3.5
+      install:
+        - make install-helm
+      script:
+        - HELM_RELEASE=lookout-style-analyzer HELM_CHART=lookout-style-analyzer K8S_NAMESPACE=lookout HELM_ARGS="--tiller-namespace=lookout --repo https://src-d.github.io/charts/ --set image.tag=$TRAVIS_TAG -f .helm_staging.yml" make deploy
   fast_finish: true
 before_script:
   - make bblfsh-start

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
 current_dir = $(shell pwd)
 
+PROJECT = style-analyzer
+
+DOCKERFILES = Dockerfile:$(PROJECT)
+DOCKER_ORG = "srcd"
+
+# Including ci Makefile
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
+CI_PATH ?= .ci
+MAKEFILE := $(CI_PATH)/Makefile.main
+$(MAKEFILE):
+	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
+-include $(MAKEFILE)
+
+
 .PHONY: check
 check:
 	! grep -R /tmp lookout/style/*/tests
 	flake8 --count
 	pylint lookout
-
-.PHONY: docker-build
-docker-build:
-	docker build -t srcd/style-analyzer .
 
 .PHONY: docker-test
 docker-test:


### PR DESCRIPTION
This deploys to GKE staging on tag. See https://travis-ci.org/src-d/style-analyzer/builds/457197144 for a run where `srcd/style-analyzer:v0.0.0-deploy-test-00` has been deployed (pypi section had been commented to avoid uploading internal tests)

Since the used branch was on the repository and has been shared by @meyskens and myself, no rebases from master have been performed. Please let me know if you prefer a single commit and I will rebase things properly.

