### PR TITLE
Add code line suggestion feature

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -1,10 +1,13 @@
 """Analyzer that detects bad formatting by learning on the existing code in the repository."""
 from itertools import chain
 import logging
+import os
 from pprint import pformat
 import threading
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Sequence, Tuple
 
+from bblfsh.client import BblfshClient
+from jinja2 import Template
 from lookout.core import slogging
 from lookout.core.analyzer import Analyzer, ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
@@ -15,13 +18,15 @@ import numpy
 from skopt import BayesSearchCV
 from skopt.space import Categorical, Integer
 
-from lookout.style.format.descriptions import get_code_chunk, get_error_description, \
-    rule_to_comment
+from lookout.style.format.classes import CLASS_INDEX, CLS_NEWLINE
+from lookout.style.format.code_generator import CodeGenerator
+from lookout.style.format.descriptions import describe_rule, get_change_description
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.model import FormatModel
 from lookout.style.format.postprocess import filter_uast_breaking_preds
-from lookout.style.format.rules import TrainableRules
-from lookout.style.format.utils import merge_dicts
+from lookout.style.format.rules import Rules, TrainableRules
+from lookout.style.format.utils import generate_comment, merge_dicts
+from lookout.style.format.virtual_node import VirtualNode
 
 
 class FormatAnalyzer(Analyzer):
@@ -38,6 +43,9 @@ class FormatAnalyzer(Analyzer):
         "report_code_lines": True,
         "report_triggered_rules": True,
         "report_parse_failures": True,
+        "uast_break_check": True,
+        "comment_template": os.path.join(os.path.dirname(__file__), "templates",
+                                         "comment_default.jinja2")
     }
     defaults_for_train = {
         "global": {
@@ -86,6 +94,8 @@ class FormatAnalyzer(Analyzer):
         """
         super().__init__(model, url, config)
         self.config = self._load_analyze_config(self.config)
+        with open(self.config["comment_template"]) as f:
+            self.comment_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
 
     @with_changed_uasts_and_contents
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
@@ -99,22 +109,6 @@ class FormatAnalyzer(Analyzer):
         :param data: Contains "changes" - the list of changes in the pointed state.
         :return: List of comments.
         """
-        def group_line_nodes(y, y_pred, vnodes_y, rule_winners):
-            line_nodes = []
-            generate_comment = False
-            for yi, y_predi, vnode_y, winner in zip(y, y_pred, vnodes_y, rule_winners):
-                if not line_nodes or vnode_y.start.line == line_nodes[0][2].start.line:
-                    # collect all nodes on the same line
-                    line_nodes.append((yi, y_predi, vnode_y, winner))
-                    if yi != y_predi:
-                        generate_comment = True
-                    continue
-                else:
-                    if generate_comment:
-                        yield line_nodes
-                    generate_comment = yi != y_predi
-                    line_nodes = [(yi, y_predi, vnode_y, winner)]
-
         log = self._log
         comments = []
         changes = list(data["changes"])
@@ -140,60 +134,15 @@ class FormatAnalyzer(Analyzer):
                         find_deleted_lines(prev_file, file),
                     )))
                 fe = FeatureExtractor(language=lang, **rules.origin_config["feature_extractor"])
-                res = fe.extract_features([file], [lines])
-                if res is None:
+                feature_extractor_output = fe.extract_features([file], [lines])
+                if feature_extractor_output is None:
                     if self.config["report_parse_failures"]:
-                        comment = Comment()
-                        comment.file = file.path
-                        comment.confidence = 100
-                        comment.line = 1
-                        comment.text = "Failed to parse this file"
-                        comment.append(comment)
+                        comments.append(
+                            generate_comment(file.path, 100, 0, "Failed to parse this file"))
                     log.warning("Failed to parse %s", file.path)
                     continue
-                X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = res
-                y_pred, rule_winners = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                                     feature_extractor=fe)
-                y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
-                    y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={file.path: file},
-                    feature_extractor=fe, stub=data_service.get_bblfsh(),
-                    vnode_parents=vnode_parents, node_parents=node_parents,
-                    rule_winners=rule_winners, log=log)
-                assert len(y) == len(y_pred)
-                assert len(y) == len(rule_winners)
-
-                code_lines = file.content.decode("utf-8", "replace").splitlines()
-                for line_nodes in group_line_nodes(y, y_pred, vnodes_y, rule_winners):
-                    code_line_number = line_nodes[0][2].start.line  # 1-based
-                    if self.config["report_triggered_rules"]:
-                        code_text = ""
-                        if self.config["report_code_lines"]:
-                            code_text = get_code_chunk(lang, code_lines, code_line_number)
-                        vnodes_comments = [
-                            "%s\n%s" % (get_error_description(vnode, y_predi, fe),
-                                        rule_to_comment(rules.rules[winner], fe, winner))
-                            for yi, y_predi, vnode, winner in line_nodes if yi != y_predi]
-                        text = "format: style mismatch:\n%s%s\n" % (
-                            code_text, "\n\n".join(vnodes_comments))
-                    else:
-                        vnodes_comments = [
-                            get_error_description(vnode, y_predi, fe)
-                            for yi, y_predi, vnode, winner in line_nodes if yi != y_predi]
-                        text = "format: style mismatch:\n%s\n" % ("\n\n".join(vnodes_comments))
-
-                    confidence = 0
-                    confidence_count = 0
-                    for yi, y_predi, _, winner in line_nodes:
-                        if yi != y_predi:
-                            confidence += rules.rules[winner].stats.conf
-                            confidence_count += 1
-
-                    comment = Comment()
-                    comment.line = code_line_number
-                    comment.text = text
-                    comment.file = file.path
-                    comment.confidence = int(round(confidence * 100 / confidence_count))
-                    comments.append(comment)
+                comments.extend(self._generate_file_comments(
+                    lang, file, fe, feature_extractor_output, rules, data_service.get_bblfsh()))
         return comments
 
     @classmethod
@@ -289,6 +238,123 @@ class FormatAnalyzer(Analyzer):
             model[language] = trainable_rules.rules
         cls._log.info("trained %s", model)
         return model
+
+    def _generate_file_comments(self, lang, file, fe, feature_extractor_output, rules,
+                                bblfsh_stub):
+        file_comments = []
+        X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = feature_extractor_output
+        y_pred, rule_winners = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
+                                             feature_extractor=fe)
+        if self.config["uast_break_check"]:
+            y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
+                y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={file.path: file},
+                feature_extractor=fe, stub=bblfsh_stub, vnode_parents=vnode_parents,
+                node_parents=node_parents, rule_winners=rule_winners, log=self._log)
+        assert len(y) == len(y_pred)
+        assert len(y) == len(rule_winners)
+        code_generator = CodeGenerator(fe, skip_errors=True)
+        new_vnodes = code_generator.apply_predicted_y(vnodes, vnodes_y, y_pred)
+        code_lines = file.content.decode("utf-8", "replace").splitlines()
+        for line_number, line in self._group_line_nodes(
+                y, y_pred, vnodes_y, new_vnodes, rule_winners):
+            line_ys, line_ys_pred, line_vnodes_y, new_line_vnodes, line_winners = line
+            new_code_line = code_generator.generate(
+                new_line_vnodes, "local").lstrip("\n").splitlines()[0]
+            change_descriptions = []
+            for line_yi, line_y_predi, line_vnode_y, line_winner in zip(
+                    line_ys, line_ys_pred, line_vnodes_y, line_winners):
+                if line_yi == line_y_predi:
+                    continue
+                change_descriptions.append(
+                    (line_winner,
+                     get_change_description(line_vnode_y, line_y_predi, fe),
+                     describe_rule(rules.rules[line_winner], fe)))
+            text = self.comment_template.render(
+                config=self.config,  # configuration of the analyzer
+                lang=lang,  # programming language of the code
+                line_number=line_number,  # line number for the comment
+                code_lines=code_lines,  # original file code lines
+                new_code_line=new_code_line,  # code line suggested by our model
+                change_descriptions=change_descriptions,  # change descriptions proposed by model
+                # List of tuples with triggered rule number, human-friendly change description and
+                # triggered rule description
+            )
+
+            file_comments.append(
+                generate_comment(
+                    filename=file.path,
+                    line=line_number,
+                    text=text,
+                    confidence=self._get_comment_confidence(
+                        line_ys, line_ys_pred, line_winners, rules)))
+
+        return file_comments
+
+    @staticmethod
+    def _get_comment_confidence(line_ys: Sequence[int], line_ys_pred: Sequence[int],
+                                line_winners: Sequence[int], rules: Rules) -> int:
+        confidence = 0
+        confidence_count = 0
+        for yi, y_predi, winner in zip(line_ys, line_ys_pred, line_winners):
+            if yi != y_predi:
+                confidence += rules.rules[winner].stats.conf
+                confidence_count += 1
+        return int(round(confidence * 100 / confidence_count))
+
+    @staticmethod
+    def _group_line_nodes(y: Sequence[int], y_pred: Sequence[int], vnodes_y: Sequence[VirtualNode],
+                          new_vnodes: Sequence[VirtualNode], rule_winners: Sequence[int]
+                          ) -> Tuple[int, Tuple]:
+        """
+        Group virtual nodes and related lists from feature extractor by line number.
+
+        It yields line number and sublists of corresponding items from all input sequences.
+        Line sublists are skipped in case there is no difference in predicted and original labels.
+        Line sublists are merged in case new line on the end was replaced by target without
+        newline. It is a helper function for `FormatAnalyser._generate_file_comments()`
+
+        :param y: Sequence of original labels.
+        :param y_pred: Sequence of predicted labels by the model.
+        :param vnodes_y: Sequence of the labeled `VirtualNode`-s corresponding to labeled samples.
+        :param new_vnodes: Sequence of all the `VirtualNode`-s corresponding to the input with \
+                           applied predictions. `CodeGenerator.apply_predicted_y()` is used for \
+                           that.
+        :param rule_winners: List of rule winners.
+        :return: 1-based line number and sublists of corresponding items from all input sequences.
+        """
+        line_ys, line_ys_pred, line_vnodes_y, line_winners = [], [], [], []
+        generate_comment = False
+        vnodes_index = 0
+        for yi, y_predi, vnode_y, winner in zip(y, y_pred, vnodes_y, rule_winners):
+            if not line_ys or vnode_y.start.line == line_vnodes_y[0].start.line:
+                # collect all nodes on the same line
+                line_ys.append(yi)
+                line_ys_pred.append(y_predi)
+                line_vnodes_y.append(vnode_y)
+                line_winners.append(winner)
+                if yi != y_predi:
+                    generate_comment = True
+                continue
+            else:
+                if generate_comment:
+                    line_vnodes = []
+                    for vnode in new_vnodes[vnodes_index:]:
+                        if vnode.start.line > line_vnodes_y[0].start.line:
+                            if (line_vnodes[-1].y is not None and
+                                    CLASS_INDEX[CLS_NEWLINE] in line_vnodes[-1].y):
+                                break
+                            else:
+                                line_vnodes.append(vnode)
+                                continue
+                        if vnode.end.line < line_vnodes_y[0].start.line:
+                            continue
+                        line_vnodes.append(vnode)
+                        vnodes_index += 1
+                    yield (int(line_vnodes_y[0].start.line),
+                           (line_ys, line_ys_pred, line_vnodes_y, line_vnodes, line_winners))
+                generate_comment = yi != y_predi
+                line_ys, line_ys_pred, line_vnodes_y, line_winners = (
+                    [yi], [y_predi], [vnode_y], [winner])
 
     @classmethod
     def _load_analyze_config(cls, config: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -322,6 +322,7 @@ class FormatAnalyzer(Analyzer):
                 vnodes=fix_vnodes,            # corrected VirtualNode-s
                 fixed_labels=fix_ys,          # predicted labels for those nodes
                 confidence=confidence,        # overall confidence in the prediction, 0-100
+                feature_extractor=fe,         # FeatureExtractor involved.
             )
             file_comments.append(generate_comment(
                 filename=file.path, line=line_number, text=text, confidence=confidence))

--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -7,7 +7,6 @@ from pprint import pformat
 import threading
 from typing import Any, List, Mapping, Sequence, Tuple
 
-from bblfsh.client import BblfshClient
 from jinja2 import Template
 from lookout.core import slogging
 from lookout.core.analyzer import Analyzer, ReferencePointer
@@ -16,6 +15,10 @@ from lookout.core.api.service_data_pb2 import File
 from lookout.core.data_requests import DataService, \
     with_changed_uasts_and_contents, with_uasts_and_contents
 from lookout.core.lib import files_by_language, filter_files, find_deleted_lines, find_new_lines
+import numpy
+from skopt import BayesSearchCV
+from skopt.space import Categorical, Integer
+
 from lookout.style.format.classes import CLASS_INDEX, CLS_NEWLINE
 from lookout.style.format.code_generator import CodeGenerator
 from lookout.style.format.descriptions import describe_rule, get_change_description
@@ -25,9 +28,6 @@ from lookout.style.format.postprocess import filter_uast_breaking_preds
 from lookout.style.format.rules import Rules, TrainableRules
 from lookout.style.format.utils import generate_comment, merge_dicts
 from lookout.style.format.virtual_node import VirtualNode
-import numpy
-from skopt import BayesSearchCV
-from skopt.space import Categorical, Integer
 
 
 class FormatAnalyzer(Analyzer):
@@ -98,6 +98,47 @@ class FormatAnalyzer(Analyzer):
         with open(self.config["comment_template"], encoding="utf-8") as f:
             self.comment_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
 
+    def _analyze_unrendered(self, data_service: DataService, changes: Sequence):
+        log = self._log
+        base_files_by_lang = files_by_language(c.base for c in changes)
+        head_files_by_lang = files_by_language(c.head for c in changes)
+        for lang, head_files in head_files_by_lang.items():
+            if lang not in self.model:
+                log.warning("skipped %d written in %s. Rules for %s do not exist in model",
+                            len(head_files), lang, lang)
+                continue
+            rules = self.model[lang]
+            rules = rules.filter_by_confidence(self.config["confidence_threshold"]) \
+                .filter_by_support(self.config["support_threshold"])
+            for head_file in filter_files(head_files, rules.origin_config["line_length_limit"],
+                                          log):
+                log.debug("Analyze %s file", head_file.path)
+                try:
+                    base_file = base_files_by_lang[lang][head_file.path]
+                except KeyError:
+                    lines = None
+                else:
+                    lines = sorted(chain.from_iterable((
+                        find_new_lines(base_file, head_file),
+                        find_deleted_lines(base_file, head_file),
+                    )))
+                fe = FeatureExtractor(language=lang, **rules.origin_config["feature_extractor"])
+                feature_extractor_output = fe.extract_features([head_file], [lines])
+                if feature_extractor_output is None:
+                    if self.config["report_parse_failures"]:
+                        log.warning("Failed to parse %s", head_file.path)
+                        yield dict(
+                            status="FAIL",
+                            filename=head_file.path,
+                            confidence=100,
+                            line_number=0,
+                            error="Failed to parse this file"
+                        )
+                else:
+                    yield from self._generate_comments_data(
+                        lang, head_file, base_file, fe, feature_extractor_output,
+                        data_service.get_bblfsh())
+
     @with_changed_uasts_and_contents
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
                 data_service: DataService, **data) -> List[Comment]:
@@ -110,40 +151,16 @@ class FormatAnalyzer(Analyzer):
         :param data: Contains "changes" - the list of changes in the pointed state.
         :return: List of comments.
         """
-        log = self._log
         comments = []
-        changes = list(data["changes"])
-        base_files_by_lang = files_by_language(c.base for c in changes)
-        head_files_by_lang = files_by_language(c.head for c in changes)
-        for lang, head_files in head_files_by_lang.items():
-            if lang not in self.model:
-                log.warning("skipped %d written in %s. Rules for %s do not exist in model",
-                            len(head_files), lang, lang)
-                continue
-            rules = self.model[lang]
-            rules = rules.filter_by_confidence(self.config["confidence_threshold"]) \
-                .filter_by_support(self.config["support_threshold"])
-            for file in filter_files(head_files, rules.origin_config["line_length_limit"], log):
-                log.debug("Analyze %s file", file.path)
-                try:
-                    prev_file = base_files_by_lang[lang][file.path]
-                except KeyError:
-                    lines = None
-                else:
-                    lines = sorted(chain.from_iterable((
-                        find_new_lines(prev_file, file),
-                        find_deleted_lines(prev_file, file),
-                    )))
-                fe = FeatureExtractor(language=lang, **rules.origin_config["feature_extractor"])
-                feature_extractor_output = fe.extract_features([file], [lines])
-                if feature_extractor_output is None:
-                    if self.config["report_parse_failures"]:
-                        comments.append(
-                            generate_comment(file.path, 100, 0, "Failed to parse this file"))
-                    log.warning("Failed to parse %s", file.path)
-                    continue
-                comments.extend(self._generate_file_comments(
-                    lang, file, fe, feature_extractor_output, data_service.get_bblfsh()))
+        for unrendered_data in self._analyze_unrendered(data_service, list(data["changes"])):
+            if unrendered_data["status"] == "OK":
+                comments.append(self.render_comment(**unrendered_data))
+            else:
+                comments.append(generate_comment(
+                    filename=unrendered_data["filename"],
+                    line=unrendered_data["line_number"],
+                    text=unrendered_data["error"],
+                    confidence=unrendered_data["confidence"]))
         return comments
 
     @classmethod
@@ -240,63 +257,68 @@ class FormatAnalyzer(Analyzer):
         cls._log.info("trained %s", model)
         return model
 
-    def render_comment_text(
-            self, language: str, line_number: int, code_lines: List[str], new_code_line: str,
+    def render_comment(
+            self, *, language: str, line_number: int, base_file: str, new_code_line: str,
             winners: List[int], vnodes: List[VirtualNode], fixed_labels: List[int],
-            confidence: int, feature_extractor: FeatureExtractor) -> str:
+            confidence: int, feature_extractor: FeatureExtractor, filename: str, **_) -> str:
         """
-        Generate the text of the comment at the specified line.
+        Generate the comment at the specified line.
 
         :param language: Programming language of the code.
         :param line_number: Line number for the comment.
-        :param code_lines: Original file code lines.
+        :param base_file: Original file content.
         :param new_code_line: Code line suggested by our model.
         :param winners: Winner rule indices.
         :param vnodes: Corrected VirtualNode-s on the line.
         :param fixed_labels: Predicted labels for those `vnodes`.
         :param confidence: Overall confidence in the prediction, 0-100.
         :param feature_extractor: FeatureExtractor involved.
+        :param filename: Name of the file.
+        :param _: All other keyword parameters are ignored.
         :return: string with the generated comment.
         """
         rules = self.model[language]
         _describe_rule = functools.partial(describe_rule, feature_extractor=feature_extractor)
         _describe_change = functools.partial(
             get_change_description, feature_extractor=feature_extractor)
-        return self.comment_template.render(
-                config=self.config,                # configuration of the analyzer
-                language=language,                 # programming language of the code
-                line_number=line_number,           # line number for the comment
-                code_lines=code_lines,             # original file code lines
-                new_code_line=new_code_line,       # code line suggested by our model
-                rules=rules.rules,                 # list of rules belonging to the model
-                winners=winners,                   # winner rule indices
-                vnodes=vnodes,                     # corrected VirtualNode-s
-                fixed_labels=fixed_labels,         # predicted labels for those nodes
-                confidence=confidence,             # overall confidence in the prediction, 0-100
-                describe_rule=_describe_rule,      # function to format a rule as text
-                describe_change=_describe_change,  # function to format a change as text
-                zip=zip,                           # Jinja2 does not have zip() by default
+        text = self.comment_template.render(
+                config=self.config,                 # configuration of the analyzer
+                language=language,                  # programming language of the code
+                line_number=line_number,            # line number for the comment
+                code_lines=base_file.splitlines(),  # original file code lines
+                new_code_line=new_code_line,        # code line suggested by our model
+                rules=rules.rules,                  # list of rules belonging to the model
+                winners=winners,                    # winner rule indices
+                vnodes=vnodes,                      # corrected VirtualNode-s
+                fixed_labels=fixed_labels,          # predicted labels for those nodes
+                confidence=confidence,              # overall confidence in the prediction, 0-100
+                describe_rule=_describe_rule,       # function to format a rule as text
+                describe_change=_describe_change,   # function to format a change as text
+                zip=zip,                            # Jinja2 does not have zip() by default
             )
+        return generate_comment(
+            filename=filename, line=line_number, text=text, confidence=confidence)
 
-    def _generate_file_comments(
-            self, language: str, file: File, fe: FeatureExtractor,
+    def _generate_comments_data(
+            self, language: str, head_file: File, base_file: File, fe: FeatureExtractor,
             feature_extractor_output, bblfsh_stub: "bblfsh.aliases.ProtocolServiceStub"
             ) -> List[Comment]:
         rules = self.model[language]
-        file_comments = []
         X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = feature_extractor_output
         y_pred, rule_winners = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
                                              feature_extractor=fe)
         if self.config["uast_break_check"]:
             y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
-                y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={file.path: file},
-                feature_extractor=fe, stub=bblfsh_stub, vnode_parents=vnode_parents,
-                node_parents=node_parents, rule_winners=rule_winners, log=self._log)
+                y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes,
+                files={head_file.path: head_file}, feature_extractor=fe, stub=bblfsh_stub,
+                vnode_parents=vnode_parents, node_parents=node_parents, rule_winners=rule_winners,
+                log=self._log)
         assert len(y) == len(y_pred)
         assert len(y) == len(rule_winners)
         code_generator = CodeGenerator(fe, skip_errors=True)
         new_vnodes = code_generator.apply_predicted_y(vnodes, vnodes_y, y_pred)
-        code_lines = file.content.decode("utf-8", "replace").splitlines()
+        head_file_text = head_file.content.decode("utf-8", "replace")
+        base_file_text = base_file.content.decode("utf-8", "replace")
         for line_number, line in self._group_line_nodes(
                 y, y_pred, vnodes_y, new_vnodes, rule_winners):
             line_ys, line_ys_pred, line_vnodes_y, new_line_vnodes, line_winners = line
@@ -313,19 +335,21 @@ class FormatAnalyzer(Analyzer):
                 fix_vnodes.append(line_vnode_y)
                 fix_ys.append(line_y_predi)
             confidence = self._get_comment_confidence(line_ys, line_ys_pred, line_winners, rules)
-            text = self.render_comment_text(
-                language=language,            # programming language of the code
-                line_number=line_number,      # line number for the comment
-                code_lines=code_lines,        # original file code lines
-                new_code_line=new_code_line,  # code line suggested by our model
-                winners=fix_rules,            # winner rule indices
-                vnodes=fix_vnodes,            # corrected VirtualNode-s
-                fixed_labels=fix_ys,          # predicted labels for those nodes
-                confidence=confidence,        # overall confidence in the prediction, 0-100
+            yield dict(
+                status="OK",                      # generation status "OK" or "FAIL"
+                filename=head_file.path,          # name of the file
+                language=language,                # programming language of the code
+                line_number=line_number,          # line number for the comment
+                head_file=head_file_text,         # new file content
+                base_file=base_file_text,         # original file content
+                new_code_line=new_code_line,      # code line suggested by our model
+                winners=fix_rules,                # winner rule indices
+                vnodes=fix_vnodes,                # corrected VirtualNode-s
+                fixed_labels=fix_ys,              # predicted labels for those nodes
+                confidence=confidence,            # overall confidence in the prediction, 0-100
+                feature_extractor=fe,             # FeatureExtractor involved.
+                new_vnodes=new_vnodes,            # fixed vnodes via CodeGenerator
             )
-            file_comments.append(generate_comment(
-                filename=file.path, line=line_number, text=text, confidence=confidence))
-        return file_comments
 
     @staticmethod
     def _get_comment_confidence(line_ys: Sequence[int], line_ys_pred: Sequence[int],

--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -7,7 +7,6 @@ from pprint import pformat
 import threading
 from typing import Any, List, Mapping, Sequence, Tuple
 
-from bblfsh.client import BblfshClient
 from jinja2 import Template
 from lookout.core import slogging
 from lookout.core.analyzer import Analyzer, ReferencePointer
@@ -16,6 +15,10 @@ from lookout.core.api.service_data_pb2 import File
 from lookout.core.data_requests import DataService, \
     with_changed_uasts_and_contents, with_uasts_and_contents
 from lookout.core.lib import files_by_language, filter_files, find_deleted_lines, find_new_lines
+import numpy
+from skopt import BayesSearchCV
+from skopt.space import Categorical, Integer
+
 from lookout.style.format.classes import CLASS_INDEX, CLS_NEWLINE
 from lookout.style.format.code_generator import CodeGenerator
 from lookout.style.format.descriptions import describe_rule, get_change_description
@@ -25,9 +28,6 @@ from lookout.style.format.postprocess import filter_uast_breaking_preds
 from lookout.style.format.rules import Rules, TrainableRules
 from lookout.style.format.utils import generate_comment, merge_dicts
 from lookout.style.format.virtual_node import VirtualNode
-import numpy
-from skopt import BayesSearchCV
-from skopt.space import Categorical, Integer
 
 
 class FormatAnalyzer(Analyzer):

--- a/lookout/style/format/benchmarks/evaluate_smoke.py
+++ b/lookout/style/format/benchmarks/evaluate_smoke.py
@@ -1,35 +1,29 @@
 """Module for Smoke dataset evaluation."""
 import csv
 from difflib import SequenceMatcher
-from itertools import chain
 import json
 import logging
 import os
 from pathlib import Path
 import tempfile
 import time
-from typing import Any, Dict, List, Mapping, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from bblfsh import BblfshClient
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
-from lookout.core.api.service_data_pb2_grpc import DataStub
-from lookout.core.data_requests import with_changed_uasts_and_contents
-from lookout.core.lib import files_by_language, filter_files, find_deleted_lines, find_new_lines
+from lookout.core.data_requests import DataService, with_changed_uasts_and_contents
+from lookout.core.lib import files_by_language
 from lookout.core.test_helpers import server
-import numpy
 import pandas
 from tqdm import tqdm
 
 from lookout.style.format.analyzer import FormatAnalyzer
 from lookout.style.format.code_generator import CodeGenerator
 from lookout.style.format.feature_extractor import FeatureExtractor
-from lookout.style.format.model import FormatModel
 from lookout.style.format.tests.test_analyzer_integration import TestAnalyzer
 from lookout.style.format.utils import flatten_dict
 from lookout.style.format.virtual_node import VirtualNode
 
-log = logging.getLogger("report_summary")
 
 EMPTY = "␣"
 
@@ -160,9 +154,9 @@ def calc_aligned_metrics(bad_style_code: str, correct_style_code: str, generated
     return misdetection, undetected, detected_wrong_fix, detected_correct_fix
 
 
-def calc_metrics(bad_style_code: str, correct_style_code: str, fe: FeatureExtractor,
-                 vnodes: Sequence[VirtualNode], y_pred: numpy.ndarray, vnodes_y: numpy.ndarray,
-                 url: str, commit: str) -> Dict[str, Any]:
+def calc_metrics(bad_style_code: str, correct_style_code: str, fe: Optional[FeatureExtractor],
+                 vnodes: Optional[Sequence[VirtualNode]], url: Optional[str],
+                 commit: Optional[str]) -> Dict[str, Any]:
     """
     Calculate metrics for model output.
 
@@ -218,23 +212,26 @@ def calc_metrics(bad_style_code: str, correct_style_code: str, fe: FeatureExtrac
     :param bad_style_code: The file from head revision where style mistakes where applied.
     :param correct_style_code: The file from base revision. In ideal case, we should be able to \
                                restore it.
-    :param fe: Feature extraction class that was used to generate corresponding data.
+    :param fe: Feature extraction class that was used to generate corresponding data. Set a value \
+            to None if no changes were introduced for `bad_style_code`.
     :param vnodes: Sequence of all the `VirtualNode`-s corresponding to the input code file. \
-                   Should be ordered by position.
-    :param y_pred: The model predictions for `vnodes_y` `VirtualNode`-s.
-    :param vnodes_y: Sequence of the labeled `VirtualNode`-s corresponding to labeled samples. \
-                     Should be ordered by start position value.
+                   Should be ordered by position. New y values should be applied. Set a value to \
+                   None if no changes were introduced.
     :param url: Repository url if applicable. Useful for more informative warning messages.
     :param commit: Commit hash if applicable. Useful for more informative warning messages.
 
     :return: A dictionary with losses and predicted code for "global" and "local" indentation \
              strategies.
     """
+    if (vnodes is None) ^ (fe is None):
+        raise ValueError("vnodes and fe should be both None or not None.")
     losses = {}
     for indentation in ("global", "local"):
-        generator = CodeGenerator(fe, skip_errors=True, url=url, commit=commit)
-        predicted_vnodes = generator.apply_predicted_y(vnodes, vnodes_y, y_pred)
-        predicted_code = generator.generate(predicted_vnodes, indentation)
+        if fe is not None:
+            predicted_code = CodeGenerator(fe, skip_errors=True, url=url, commit=commit).generate(
+                vnodes, indentation)
+        else:
+            predicted_code = bad_style_code
         misdetection, undetected, detected_wrong_fix, detected_correct_fix = \
             calc_aligned_metrics(*align3(bad_style_code, correct_style_code, predicted_code))
         losses[indentation] = {
@@ -259,18 +256,6 @@ class SmokeEvalFormatAnalyzer(FormatAnalyzer):
         "bad_style_file", "correct_style_file", "local_predicted_file", "global_predicted_file",
     ]
 
-    def __init__(self, model: FormatModel, url: str, config: Mapping[str, Any]) -> None:
-        """
-        Construct a FormatAnalyzer.
-
-        :param model: FormatModel to use during pull request analysis.
-        :param url: Git repository on which the model was trained.
-        :param config: Configuration to use to analyze pull requests.
-        """
-        super().__init__(model, url, config)
-        self.config = self._load_analyze_config(self.config)
-        self.client = BblfshClient(self.config["bblfsh_address"])
-
     def _dump_report(self, report: List[dict], outputpath: Path):
         files_dir = outputpath / "files"
         os.makedirs(str(files_dir), exist_ok=True)
@@ -290,63 +275,56 @@ class SmokeEvalFormatAnalyzer(FormatAnalyzer):
 
     @with_changed_uasts_and_contents
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
-                data_request_stub: DataStub, **data) -> List[Comment]:
+                data_service: DataService, **data) -> List[Comment]:
         """
         Analyze a set of changes from one revision to another.
 
         :param ptr_from: Git repository state pointer to the base revision.
         :param ptr_to: Git repository state pointer to the head revision.
-        :param data_request_stub: Connection to the Lookout data retrieval service, not used.
+        :param data_service: Connection to the Lookout data retrieval service, not used.
         :param data: Contains "changes" - the list of changes in the pointed state.
         :return: List of comments.
         """
-        # TODO (zurk): reuse code from FormatAnalyzer.analyze()
         report = []
-        log = self._log
+        handled_files = set()
         changes = list(data["changes"])
+        for unrendered_data in self._analyze_unrendered(data_service, changes):
+            if unrendered_data["status"] != "OK" or unrendered_data["filename"] in handled_files:
+                continue
+            handled_files.add(unrendered_data["filename"])
+            row = {
+                "repo": self.config["repo_name"],
+                "filepath": unrendered_data["filename"],
+                "style": self.config["style_name"],
+                "bad_style_file": unrendered_data["head_file"],
+                "correct_style_file": unrendered_data["base_file"],
+            }
+            row.update(calc_metrics(
+                unrendered_data["head_file"], unrendered_data["base_file"],
+                unrendered_data["feature_extractor"], unrendered_data["new_vnodes"],
+                url=ptr_to.url, commit=ptr_to.commit))
+            report.append(row)
+
+        # handle file without comments:
         base_files_by_lang = files_by_language(c.base for c in changes)
         head_files_by_lang = files_by_language(c.head for c in changes)
         for lang, head_files in head_files_by_lang.items():
-            if lang not in self.model:
-                log.warning("skipped %d written in %s. Rules for %s do not exist in model",
-                            len(head_files), lang, lang)
-                continue
-            rules = self.model[lang]
-            for file in filter_files(head_files, rules.origin_config["line_length_limit"], log):
-                log.debug("Analyze %s file", file.path)
-                try:
-                    base_file = base_files_by_lang[lang][file.path]
-                except KeyError:
-                    lines = None
-                else:
-                    lines = sorted(chain.from_iterable((
-                        find_new_lines(base_file, file),
-                        find_deleted_lines(base_file, file),
-                    )))
-                fe = FeatureExtractor(language=lang, **rules.origin_config["feature_extractor"])
-                res = fe.extract_features([file], [lines])
-                if res is None:
-                    log.warning("Failed to parse %s", file.path)
+            for head_file in head_files:
+                if head_file in handled_files:
                     continue
-                X, y, (vnodes_y, vnodes, _, _) = res
-                y_pred, _ = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                          feature_extractor=fe)
-                assert len(y) == len(y_pred)
-
-                correct_style_code = base_file.content.decode("utf-8", "replace")
-                bad_style_code = file.content.decode("utf-8", "replace")
+                head_file_text = head_files_by_lang[lang][head_file].content.decode(
+                    "utf-8", "replace")
+                base_file_text = base_files_by_lang[lang][head_file].content.decode(
+                    "utf-8", "replace")
                 row = {
                     "repo": self.config["repo_name"],
-                    "filepath": file.path,
+                    "filepath": head_file,
                     "style": self.config["style_name"],
-                    "bad_style_file": bad_style_code,
-                    "correct_style_file": correct_style_code,
+                    "bad_style_file": head_file_text,
+                    "correct_style_file": base_file_text,
                 }
-                row.update(calc_metrics(
-                    bad_style_code, correct_style_code,
-                    fe, vnodes, vnodes_y, y_pred,
-                    url=ptr_to.url, commit=ptr_to.commit
-                ))
+                row.update(calc_metrics(head_file_text, base_file_text,
+                                        fe=None, vnodes=None, url=None, commit=None))
                 report.append(row)
         self._dump_report(report, Path(self.config["report_path"]))
         return []
@@ -398,9 +376,10 @@ def evaluate_smoke_entry(inputpath: str, reportdir: str, database: str = None) -
                         }
                     }
                     server.run("push", fr=row["from"], to=row["to"], port=port,
-                               git_dir=str(repopath), config_json=json.dumps(train_config))
+                               git_dir=str(repopath), log_level="warning",
+                               config_json=json.dumps(train_config))
                     server.run("review", fr=row["from"], to=row["to"], port=port,
-                               git_dir=str(repopath),
+                               git_dir=str(repopath), log_level="warning",
                                config_json=json.dumps(config_json))
             log.info("Quality report saved to %s", reportdir)
 

--- a/lookout/style/format/benchmarks/evaluate_smoke.py
+++ b/lookout/style/format/benchmarks/evaluate_smoke.py
@@ -10,7 +10,6 @@ import tempfile
 import time
 from typing import Any, Dict, List, Mapping, Sequence, Tuple, Union
 
-from bblfsh import BblfshClient
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2_grpc import DataStub
@@ -269,7 +268,6 @@ class SmokeEvalFormatAnalyzer(FormatAnalyzer):
         """
         super().__init__(model, url, config)
         self.config = self._load_analyze_config(self.config)
-        self.client = BblfshClient(self.config["bblfsh_address"])
 
     def _dump_report(self, report: List[dict], outputpath: Path):
         files_dir = outputpath / "files"

--- a/lookout/style/format/benchmarks/evaluate_smoke.py
+++ b/lookout/style/format/benchmarks/evaluate_smoke.py
@@ -1,29 +1,35 @@
 """Module for Smoke dataset evaluation."""
 import csv
 from difflib import SequenceMatcher
+from itertools import chain
 import json
 import logging
 import os
 from pathlib import Path
 import tempfile
 import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Mapping, Sequence, Tuple, Union
 
+from bblfsh import BblfshClient
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
-from lookout.core.data_requests import DataService, with_changed_uasts_and_contents
-from lookout.core.lib import files_by_language
+from lookout.core.api.service_data_pb2_grpc import DataStub
+from lookout.core.data_requests import with_changed_uasts_and_contents
+from lookout.core.lib import files_by_language, filter_files, find_deleted_lines, find_new_lines
 from lookout.core.test_helpers import server
+import numpy
 import pandas
 from tqdm import tqdm
 
 from lookout.style.format.analyzer import FormatAnalyzer
 from lookout.style.format.code_generator import CodeGenerator
 from lookout.style.format.feature_extractor import FeatureExtractor
+from lookout.style.format.model import FormatModel
 from lookout.style.format.tests.test_analyzer_integration import TestAnalyzer
 from lookout.style.format.utils import flatten_dict
 from lookout.style.format.virtual_node import VirtualNode
 
+log = logging.getLogger("report_summary")
 
 EMPTY = "␣"
 
@@ -154,9 +160,9 @@ def calc_aligned_metrics(bad_style_code: str, correct_style_code: str, generated
     return misdetection, undetected, detected_wrong_fix, detected_correct_fix
 
 
-def calc_metrics(bad_style_code: str, correct_style_code: str, fe: Optional[FeatureExtractor],
-                 vnodes: Optional[Sequence[VirtualNode]], url: Optional[str],
-                 commit: Optional[str]) -> Dict[str, Any]:
+def calc_metrics(bad_style_code: str, correct_style_code: str, fe: FeatureExtractor,
+                 vnodes: Sequence[VirtualNode], y_pred: numpy.ndarray, vnodes_y: numpy.ndarray,
+                 url: str, commit: str) -> Dict[str, Any]:
     """
     Calculate metrics for model output.
 
@@ -212,26 +218,23 @@ def calc_metrics(bad_style_code: str, correct_style_code: str, fe: Optional[Feat
     :param bad_style_code: The file from head revision where style mistakes where applied.
     :param correct_style_code: The file from base revision. In ideal case, we should be able to \
                                restore it.
-    :param fe: Feature extraction class that was used to generate corresponding data. Set a value \
-            to None if no changes were introduced for `bad_style_code`.
+    :param fe: Feature extraction class that was used to generate corresponding data.
     :param vnodes: Sequence of all the `VirtualNode`-s corresponding to the input code file. \
-                   Should be ordered by position. New y values should be applied. Set a value to \
-                   None if no changes were introduced.
+                   Should be ordered by position.
+    :param y_pred: The model predictions for `vnodes_y` `VirtualNode`-s.
+    :param vnodes_y: Sequence of the labeled `VirtualNode`-s corresponding to labeled samples. \
+                     Should be ordered by start position value.
     :param url: Repository url if applicable. Useful for more informative warning messages.
     :param commit: Commit hash if applicable. Useful for more informative warning messages.
 
     :return: A dictionary with losses and predicted code for "global" and "local" indentation \
              strategies.
     """
-    if (vnodes is None) ^ (fe is None):
-        raise ValueError("vnodes and fe should be both None or not None.")
     losses = {}
     for indentation in ("global", "local"):
-        if fe is not None:
-            predicted_code = CodeGenerator(fe, skip_errors=True, url=url, commit=commit).generate(
-                vnodes, indentation)
-        else:
-            predicted_code = bad_style_code
+        generator = CodeGenerator(fe, skip_errors=True, url=url, commit=commit)
+        predicted_vnodes = generator.apply_predicted_y(vnodes, vnodes_y, y_pred)
+        predicted_code = generator.generate(predicted_vnodes, indentation)
         misdetection, undetected, detected_wrong_fix, detected_correct_fix = \
             calc_aligned_metrics(*align3(bad_style_code, correct_style_code, predicted_code))
         losses[indentation] = {
@@ -256,6 +259,18 @@ class SmokeEvalFormatAnalyzer(FormatAnalyzer):
         "bad_style_file", "correct_style_file", "local_predicted_file", "global_predicted_file",
     ]
 
+    def __init__(self, model: FormatModel, url: str, config: Mapping[str, Any]) -> None:
+        """
+        Construct a FormatAnalyzer.
+
+        :param model: FormatModel to use during pull request analysis.
+        :param url: Git repository on which the model was trained.
+        :param config: Configuration to use to analyze pull requests.
+        """
+        super().__init__(model, url, config)
+        self.config = self._load_analyze_config(self.config)
+        self.client = BblfshClient(self.config["bblfsh_address"])
+
     def _dump_report(self, report: List[dict], outputpath: Path):
         files_dir = outputpath / "files"
         os.makedirs(str(files_dir), exist_ok=True)
@@ -275,56 +290,63 @@ class SmokeEvalFormatAnalyzer(FormatAnalyzer):
 
     @with_changed_uasts_and_contents
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
-                data_service: DataService, **data) -> List[Comment]:
+                data_request_stub: DataStub, **data) -> List[Comment]:
         """
         Analyze a set of changes from one revision to another.
 
         :param ptr_from: Git repository state pointer to the base revision.
         :param ptr_to: Git repository state pointer to the head revision.
-        :param data_service: Connection to the Lookout data retrieval service, not used.
+        :param data_request_stub: Connection to the Lookout data retrieval service, not used.
         :param data: Contains "changes" - the list of changes in the pointed state.
         :return: List of comments.
         """
+        # TODO (zurk): reuse code from FormatAnalyzer.analyze()
         report = []
-        handled_files = set()
+        log = self._log
         changes = list(data["changes"])
-        for unrendered_data in self._analyze_unrendered(data_service, changes):
-            if unrendered_data["status"] != "OK" or unrendered_data["filename"] in handled_files:
-                continue
-            handled_files.add(unrendered_data["filename"])
-            row = {
-                "repo": self.config["repo_name"],
-                "filepath": unrendered_data["filename"],
-                "style": self.config["style_name"],
-                "bad_style_file": unrendered_data["head_file"],
-                "correct_style_file": unrendered_data["base_file"],
-            }
-            row.update(calc_metrics(
-                unrendered_data["head_file"], unrendered_data["base_file"],
-                unrendered_data["feature_extractor"], unrendered_data["new_vnodes"],
-                url=ptr_to.url, commit=ptr_to.commit))
-            report.append(row)
-
-        # handle file without comments:
         base_files_by_lang = files_by_language(c.base for c in changes)
         head_files_by_lang = files_by_language(c.head for c in changes)
         for lang, head_files in head_files_by_lang.items():
-            for head_file in head_files:
-                if head_file in handled_files:
+            if lang not in self.model:
+                log.warning("skipped %d written in %s. Rules for %s do not exist in model",
+                            len(head_files), lang, lang)
+                continue
+            rules = self.model[lang]
+            for file in filter_files(head_files, rules.origin_config["line_length_limit"], log):
+                log.debug("Analyze %s file", file.path)
+                try:
+                    base_file = base_files_by_lang[lang][file.path]
+                except KeyError:
+                    lines = None
+                else:
+                    lines = sorted(chain.from_iterable((
+                        find_new_lines(base_file, file),
+                        find_deleted_lines(base_file, file),
+                    )))
+                fe = FeatureExtractor(language=lang, **rules.origin_config["feature_extractor"])
+                res = fe.extract_features([file], [lines])
+                if res is None:
+                    log.warning("Failed to parse %s", file.path)
                     continue
-                head_file_text = head_files_by_lang[lang][head_file].content.decode(
-                    "utf-8", "replace")
-                base_file_text = base_files_by_lang[lang][head_file].content.decode(
-                    "utf-8", "replace")
+                X, y, (vnodes_y, vnodes, _, _) = res
+                y_pred, _ = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
+                                          feature_extractor=fe)
+                assert len(y) == len(y_pred)
+
+                correct_style_code = base_file.content.decode("utf-8", "replace")
+                bad_style_code = file.content.decode("utf-8", "replace")
                 row = {
                     "repo": self.config["repo_name"],
-                    "filepath": head_file,
+                    "filepath": file.path,
                     "style": self.config["style_name"],
-                    "bad_style_file": head_file_text,
-                    "correct_style_file": base_file_text,
+                    "bad_style_file": bad_style_code,
+                    "correct_style_file": correct_style_code,
                 }
-                row.update(calc_metrics(head_file_text, base_file_text,
-                                        fe=None, vnodes=None, url=None, commit=None))
+                row.update(calc_metrics(
+                    bad_style_code, correct_style_code,
+                    fe, vnodes, vnodes_y, y_pred,
+                    url=ptr_to.url, commit=ptr_to.commit
+                ))
                 report.append(row)
         self._dump_report(report, Path(self.config["report_path"]))
         return []
@@ -376,10 +398,9 @@ def evaluate_smoke_entry(inputpath: str, reportdir: str, database: str = None) -
                         }
                     }
                     server.run("push", fr=row["from"], to=row["to"], port=port,
-                               git_dir=str(repopath), log_level="warning",
-                               config_json=json.dumps(train_config))
+                               git_dir=str(repopath), config_json=json.dumps(train_config))
                     server.run("review", fr=row["from"], to=row["to"], port=port,
-                               git_dir=str(repopath), log_level="warning",
+                               git_dir=str(repopath),
                                config_json=json.dumps(config_json))
             log.info("Quality report saved to %s", reportdir)
 

--- a/lookout/style/format/descriptions.py
+++ b/lookout/style/format/descriptions.py
@@ -186,8 +186,8 @@ def describe_rule_parts_ordinal(feature: OrdinalFeature, name: str,
     return "%s ≤ %d" % (name, floor(threshold))
 
 
-def get_error_description(vnode: VirtualNode, y_pred: int, feature_extractor: FeatureExtractor
-                          ) -> str:
+def get_change_description(vnode: VirtualNode, y_pred: int, feature_extractor: FeatureExtractor
+                           ) -> str:
     """
     Return the comment with regard to the correct node class.
 
@@ -208,18 +208,16 @@ def get_error_description(vnode: VirtualNode, y_pred: int, feature_extractor: Fe
         class_representations[y], class_representations[y_pred], column)
 
 
-def get_code_chunk(lang: str, code_lines: Sequence[str], line_number: int) -> str:
+def get_code_chunk(code_lines: Sequence[str], line_number: int) -> str:
     """
     Return nice code snippet that can be inserted to github message.
 
-    :param lang: Code language. Both styles `javascript` and `JavaScript` are suitable.
     :param code_lines: Sequence of code lines without ending new line character.
     :param line_number: 1-based line number to print.
     :return: Code snippet.
     """
     lines = list(range(max(0, line_number - 2), line_number + 1))
-    code_chunk = "\n".join("%d|%s" % (l, code_lines[l]) for l in lines)
-    return "```%s\n%s\n```\n" % (lang, code_chunk)
+    return "\n".join("%d|%s" % (l, code_lines[l]) for l in lines)
 
 
 def rule_to_comment(rule: Rule, feature_extractor: FeatureExtractor, number: Optional[int]=None

--- a/lookout/style/format/templates/comment_default.jinja2
+++ b/lookout/style/format/templates/comment_default.jinja2
@@ -12,7 +12,7 @@ format: style mismatch:
 ```
 
 {% endif %}
-{% for rule_index, vnode, y in (winners, vnodes, fixed_labels)|zip %}
+{% for rule_index, vnode, y in zip(winners, vnodes, fixed_labels) %}
 {{ describe_change(vnode, y) }}
     {% if config.report_triggered_rules %}
 Triggered rule # {{ rule_index or "<N/A>" }}

--- a/lookout/style/format/templates/comment_default.jinja2
+++ b/lookout/style/format/templates/comment_default.jinja2
@@ -1,6 +1,6 @@
 format: style mismatch:
 {% if config.report_code_lines %}
-```{{ lang }}
+```{{ language }}
 {% for l in range([0, line_number - 2]|max, [line_number + 1, code_lines|length]|min ) %}
 {{ "%d|%s" % (l + 1, code_lines[l]) }}
 {% endfor %}
@@ -12,12 +12,12 @@ format: style mismatch:
 ```
 
 {% endif %}
-{% for rule_number, change_description, rule_description in change_descriptions %}
-{{ change_description }}
+{% for rule_index, vnode, y in (winners, vnodes, fixed_labels)|zip %}
+{{ describe_change(vnode, y) }}
     {% if config.report_triggered_rules %}
-Triggered rule # {{ rule_number or "<N/A>" }}
+Triggered rule # {{ rule_index or "<N/A>" }}
 ```
-{{ rule_description }}
+{{ describe_rule(rules[rule_index]) }}
 ```
     {% endif %}
 {% endfor %}

--- a/lookout/style/format/templates/comment_default.jinja2
+++ b/lookout/style/format/templates/comment_default.jinja2
@@ -12,7 +12,7 @@ format: style mismatch:
 ```
 
 {% endif %}
-{% for rule_index, vnode, y in zip(winners, vnodes, fixed_labels) %}
+{% for rule_index, vnode, y in (winners, vnodes, fixed_labels)|zip %}
 {{ describe_change(vnode, y) }}
     {% if config.report_triggered_rules %}
 Triggered rule # {{ rule_index or "<N/A>" }}

--- a/lookout/style/format/templates/comment_default.jinja2
+++ b/lookout/style/format/templates/comment_default.jinja2
@@ -1,0 +1,23 @@
+format: style mismatch:
+{% if config.report_code_lines %}
+```{{ lang }}
+{% for l in range([0, line_number - 2]|max, [line_number + 1, code_lines|length]|min ) %}
+{{ "%d|%s" % (l + 1, code_lines[l]) }}
+{% endfor %}
+```
+{% endif %}
+{% if new_code_line != code_lines[line_number - 1] %}
+```suggestion
+{{ new_code_line }}
+```
+
+{% endif %}
+{% for rule_number, change_description, rule_description in change_descriptions %}
+{{ change_description }}
+    {% if config.report_triggered_rules %}
+Triggered rule # {{ rule_number or "<N/A>" }}
+```
+{{ rule_description }}
+```
+    {% endif %}
+{% endfor %}

--- a/lookout/style/format/tests/test_comment_generation.py
+++ b/lookout/style/format/tests/test_comment_generation.py
@@ -1,29 +1,12 @@
-import functools
 import os
 import unittest
 
-from lookout.style.format import descriptions, FormatAnalyzer
-from lookout.style.format.virtual_node import Position, VirtualNode
+from lookout.style.format import FormatAnalyzer
+from lookout.style.format.virtual_node import VirtualNode, Position
 
 
 class CodeGeneratorTests(unittest.TestCase):
     def test_template(self):
-        class FakeRules():
-            rules = {34: "<rule # 34>"}
-
-        class FakeModel:
-            def __getitem__(self, item):
-                return FakeRules()
-
-        def fake_partitial(func, *_, **__):
-            if func == descriptions.describe_rule:
-                def fake_describe_rule(rule, *_, **__):
-                    return rule
-                return fake_describe_rule
-
-            def fake_get_change_description(*_, **__):
-                return "<change description>"
-            return fake_get_change_description
         comment_template_flie = os.path.join(os.path.dirname(__file__), "..", "templates",
                                              "comment_default.jinja2")
         config = {
@@ -31,28 +14,25 @@ class CodeGeneratorTests(unittest.TestCase):
             "report_triggered_rules": True,
             "comment_template": comment_template_flie,
         }
-        analyzer = FormatAnalyzer(config=config, model=FakeModel(), url="http://github.com/x/y")
-        language = "<language>"
+        analyzer = FormatAnalyzer(config=config, model=None, url="http://github.com/x/y")
+
+        lang = "<language>"
         line_number = 2
         code_lines = ["<first code line>", "<second code line>", "<third code line>"]
         new_code_line = "<new code line>"
-        partial_backup = functools.partial
-        try:
 
-            functools.partial = fake_partitial
-            text = analyzer.render_comment_text(
-                language=language,  # programming language of the code
-                line_number=line_number,  # line number for the comment
-                code_lines=code_lines,  # original file code lines
-                new_code_line=new_code_line,  # code line suggested by our model
-                winners=[34],
-                vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1),
-                                    value="!", y=1)],
-                fixed_labels=[2],
-                confidence=99,
-                feature_extractor=None,
-            )
-            res = """format: style mismatch:
+        text = analyzer.render_comment_text(
+            language=lang,  # programming language of the code
+            line_number=line_number,  # line number for the comment
+            code_lines=code_lines,  # original file code lines
+            new_code_line=new_code_line,  # code line suggested by our model
+            winners=[34],
+            vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1), value="!", y=1)],
+            fixed_labels=[2],
+            confidence=99,
+            feature_extractor=None,
+        )
+        res = """format: style mismatch:
 ```<language>
 1|<first code line>
 2|<second code line>
@@ -62,15 +42,13 @@ class CodeGeneratorTests(unittest.TestCase):
 <new code line>
 ```
 
-<change description>
+<change description here>
 Triggered rule # 34
 ```
-<rule # 34>
+<rule description here>
 ```
 """
-            self.assertEqual(text, res)
-        finally:
-            functools.partial = partial_backup
+        self.assertEqual(text, res)
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_comment_generation.py
+++ b/lookout/style/format/tests/test_comment_generation.py
@@ -1,31 +1,36 @@
 import os
 import unittest
 
-from jinja2 import Template
+from lookout.style.format import FormatAnalyzer
+from lookout.style.format.virtual_node import VirtualNode, Position
 
 
 class CodeGeneratorTests(unittest.TestCase):
     def test_template(self):
-        comment_template_flie = os.path.join(os.path.dirname(__file__), "../templates",
+        comment_template_flie = os.path.join(os.path.dirname(__file__), "..", "templates",
                                              "comment_default.jinja2")
-        with open(comment_template_flie) as f:
-            comment_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
         config = {
             "report_code_lines": True,
-            "report_triggered_rules": True}
+            "report_triggered_rules": True,
+            "comment_template": comment_template_flie,
+        }
+        analyzer = FormatAnalyzer(config=config, model=None, url="http://github.com/x/y")
+
         lang = "<language>"
         line_number = 2
         code_lines = ["<first code line>", "<second code line>", "<third code line>"]
         new_code_line = "<new code line>"
-        change_descriptions = [(34, "<change description here>", "<rule description here>")]
 
-        text = comment_template.render(
-            config=config,  # configuration of the analyzer
-            lang=lang,  # programming language of the code
+        text = analyzer.render_comment_text(
+            language=lang,  # programming language of the code
             line_number=line_number,  # line number for the comment
             code_lines=code_lines,  # original file code lines
             new_code_line=new_code_line,  # code line suggested by our model
-            change_descriptions=change_descriptions,  # change descriptions proposed by model
+            winners=[34],
+            vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1), value="!", y=1)],
+            fixed_labels=[2],
+            confidence=99,
+            feature_extractor=None,
         )
         res = """format: style mismatch:
 ```<language>
@@ -42,29 +47,6 @@ Triggered rule # 34
 ```
 <rule description here>
 ```
-"""
-        self.assertEqual(text, res)
-
-        config = {
-            "report_code_lines": False,
-            "report_triggered_rules": False}
-        change_descriptions = [(34, "<change description here>", "<rule description here>"),
-                               (35, "<change2 description here>", "<rule2 description here>")]
-        text = comment_template.render(
-            config=config,  # configuration of the analyzer
-            lang=lang,  # programming language of the code
-            line_number=line_number,  # line number for the comment
-            code_lines=code_lines,  # original file code lines
-            new_code_line=new_code_line,  # code line suggested by our model
-            change_descriptions=change_descriptions,  # change descriptions proposed by model
-        )
-        res = """format: style mismatch:
-```suggestion
-<new code line>
-```
-
-<change description here>
-<change2 description here>
 """
         self.assertEqual(text, res)
 

--- a/lookout/style/format/tests/test_comment_generation.py
+++ b/lookout/style/format/tests/test_comment_generation.py
@@ -1,12 +1,29 @@
+import functools
 import os
 import unittest
 
-from lookout.style.format import FormatAnalyzer
-from lookout.style.format.virtual_node import VirtualNode, Position
+from lookout.style.format import descriptions, FormatAnalyzer
+from lookout.style.format.virtual_node import Position, VirtualNode
 
 
 class CodeGeneratorTests(unittest.TestCase):
     def test_template(self):
+        class FakeRules():
+            rules = {34: "<rule # 34>"}
+
+        class FakeModel:
+            def __getitem__(self, item):
+                return FakeRules()
+
+        def fake_partitial(func, *_, **__):
+            if func == descriptions.describe_rule:
+                def fake_describe_rule(rule, *_, **__):
+                    return rule
+                return fake_describe_rule
+
+            def fake_get_change_description(*_, **__):
+                return "<change description>"
+            return fake_get_change_description
         comment_template_flie = os.path.join(os.path.dirname(__file__), "..", "templates",
                                              "comment_default.jinja2")
         config = {
@@ -14,25 +31,28 @@ class CodeGeneratorTests(unittest.TestCase):
             "report_triggered_rules": True,
             "comment_template": comment_template_flie,
         }
-        analyzer = FormatAnalyzer(config=config, model=None, url="http://github.com/x/y")
-
-        lang = "<language>"
+        analyzer = FormatAnalyzer(config=config, model=FakeModel(), url="http://github.com/x/y")
+        language = "<language>"
         line_number = 2
         code_lines = ["<first code line>", "<second code line>", "<third code line>"]
         new_code_line = "<new code line>"
+        partial_backup = functools.partial
+        try:
 
-        text = analyzer.render_comment_text(
-            language=lang,  # programming language of the code
-            line_number=line_number,  # line number for the comment
-            code_lines=code_lines,  # original file code lines
-            new_code_line=new_code_line,  # code line suggested by our model
-            winners=[34],
-            vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1), value="!", y=1)],
-            fixed_labels=[2],
-            confidence=99,
-            feature_extractor=None,
-        )
-        res = """format: style mismatch:
+            functools.partial = fake_partitial
+            text = analyzer.render_comment_text(
+                language=language,  # programming language of the code
+                line_number=line_number,  # line number for the comment
+                code_lines=code_lines,  # original file code lines
+                new_code_line=new_code_line,  # code line suggested by our model
+                winners=[34],
+                vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1),
+                                    value="!", y=1)],
+                fixed_labels=[2],
+                confidence=99,
+                feature_extractor=None,
+            )
+            res = """format: style mismatch:
 ```<language>
 1|<first code line>
 2|<second code line>
@@ -42,13 +62,15 @@ class CodeGeneratorTests(unittest.TestCase):
 <new code line>
 ```
 
-<change description here>
+<change description>
 Triggered rule # 34
 ```
-<rule description here>
+<rule # 34>
 ```
 """
-        self.assertEqual(text, res)
+            self.assertEqual(text, res)
+        finally:
+            functools.partial = partial_backup
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_comment_generation.py
+++ b/lookout/style/format/tests/test_comment_generation.py
@@ -1,0 +1,73 @@
+import os
+import unittest
+
+from jinja2 import Template
+
+
+class CodeGeneratorTests(unittest.TestCase):
+    def test_template(self):
+        comment_template_flie = os.path.join(os.path.dirname(__file__), "../templates",
+                                             "comment_default.jinja2")
+        with open(comment_template_flie) as f:
+            comment_template = Template(f.read(), trim_blocks=True, lstrip_blocks=True)
+        config = {
+            "report_code_lines": True,
+            "report_triggered_rules": True}
+        lang = "<language>"
+        line_number = 2
+        code_lines = ["<first code line>", "<second code line>", "<third code line>"]
+        new_code_line = "<new code line>"
+        change_descriptions = [(34, "<change description here>", "<rule description here>")]
+
+        text = comment_template.render(
+            config=config,  # configuration of the analyzer
+            lang=lang,  # programming language of the code
+            line_number=line_number,  # line number for the comment
+            code_lines=code_lines,  # original file code lines
+            new_code_line=new_code_line,  # code line suggested by our model
+            change_descriptions=change_descriptions,  # change descriptions proposed by model
+        )
+        res = """format: style mismatch:
+```<language>
+1|<first code line>
+2|<second code line>
+3|<third code line>
+```
+```suggestion
+<new code line>
+```
+
+<change description here>
+Triggered rule # 34
+```
+<rule description here>
+```
+"""
+        self.assertEqual(text, res)
+
+        config = {
+            "report_code_lines": False,
+            "report_triggered_rules": False}
+        change_descriptions = [(34, "<change description here>", "<rule description here>"),
+                               (35, "<change2 description here>", "<rule2 description here>")]
+        text = comment_template.render(
+            config=config,  # configuration of the analyzer
+            lang=lang,  # programming language of the code
+            line_number=line_number,  # line number for the comment
+            code_lines=code_lines,  # original file code lines
+            new_code_line=new_code_line,  # code line suggested by our model
+            change_descriptions=change_descriptions,  # change descriptions proposed by model
+        )
+        res = """format: style mismatch:
+```suggestion
+<new code line>
+```
+
+<change description here>
+<change2 description here>
+"""
+        self.assertEqual(text, res)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Also, Rework FormatAnalyzer.analyze() function.
Closes https://github.com/src-d/style-analyzer/issues/334

Full debug comment now looks like:

-------
format: style mismatch:
```javascript
388|            // Multiple arguments are aggregated like Promise.all array elements
389|            while (i--) {
390|                    adoptValue( resolveValues[ i ], updateFunc(i), master.reject );
```

```suggestion
            while ( i-- ) {
```

Insert ␣ at column 15.
Triggered rule # 1:
```
        <RULE # 1 HERE>
        Confidence: 1.000. Support: 100.
```
Insert ␣ at column 18.
Triggered rule # 22:
```  
        <RULE # 2 HERE>
        Confidence: 1.000. Support: 100.
```

-------

And without debug info: 

-------
format: style mismatch:
Insert ␣ at column 15.
Insert ␣ at column 18.
```suggestion
            while ( i-- ) {
```
-------

^ this last block is line suggestion block