### PR TITLE
Resolve the conflict between src-d/ml and src-d/style-analyzer scikit-learn versions

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -76,6 +76,7 @@ class FormatAnalyzer(Analyzer):
             },
             "n_jobs": -1,
             "n_iter": 5,
+            "cv": 3,
             "line_length_limit": 500,
             "lower_bound_instances": 500,
             "cutoff_label_precision": 0.85,
@@ -204,6 +205,7 @@ class FormatAnalyzer(Analyzer):
                  "min_samples_leaf": Integer(1, 20)},
                 n_jobs=lang_config["n_jobs"],
                 n_iter=lang_config["n_iter"],
+                cv=lang_config["cv"],
                 random_state=lang_config["trainable_rules"]["random_state"])
             if not slogging.logs_are_structured:
                 # fool the check in joblib - everything still works without it

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sourced-ml==0.7.0
 lookout-sdk-ml==0.2.2
-scikit-learn==0.19.2
+scikit-learn==0.20.1
 scikit-optimize==0.5.2
 pandas==0.22.0
 gensim==3.6.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "sourced-ml>=0.7.0,<0.8",
         "lookout-sdk-ml>=0.2.2,<0.3",
-        "scikit-learn>=0.19,<0.20.0",
+        "scikit-learn>=0.20,<2.0",
         "scikit-optimize>=0.5,<2.0",
         "pandas>=0.22,<2.0",
         "gensim>=3.5.0,<4.0",


### PR DESCRIPTION
style-analyzer was incompatible with sklearn 0.20 and src-d/ml recently bumped to it. This PR fixes the main incompatibility + the main warning we got after upgrade.

Signed-off-by: Hugo Mougard <hugo@sourced.tech>