### PR TITLE
Fix _group_line_nodes if line_vnodes is empty

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -386,7 +386,7 @@ class FormatAnalyzer(Analyzer):
                     line_vnodes = []
                     for vnode in new_vnodes[vnodes_index:]:
                         if vnode.start.line > line_vnodes_y[0].start.line:
-                            if (line_vnodes[-1].y is not None and
+                            if (line_vnodes and line_vnodes[-1].y is not None and
                                     CLASS_INDEX[CLS_NEWLINE] in line_vnodes[-1].y):
                                 break
                             else:


### PR DESCRIPTION
There is a case exists when`line_vnodes` empty but we are trying to get `-1` element.