### PR TITLE
Fix for CodeGenerator.gerenate() and FeatureExtractor._add_noops() if we remove labels with low support

### DIFF
--- a/lookout/style/format/code_generator.py
+++ b/lookout/style/format/code_generator.py
@@ -72,10 +72,12 @@ class CodeGenerator:
         """
         result = []
         for vnode, y_new in self._iterate_vnodes(vnodes, vnodes_y, y_pred):
-            vnode = vnode.copy()
-            if y_new != vnode.y:
-                vnode.y, vnode.y_old = y_new, vnode.y
-            result.append(vnode)
+            new_vnode = vnode.copy()
+            if hasattr(vnode, "y_original"):
+                new_vnode.y_original = vnode.y_original
+            if y_new != new_vnode.y:
+                new_vnode.y, new_vnode.y_old = tuple(y_new), new_vnode.y
+            result.append(new_vnode)
         return result
 
     def generate(self, vnodes: Sequence[VirtualNode], indentation: str) -> str:
@@ -95,6 +97,8 @@ class CodeGenerator:
             y_new = vnode.y
             y_old = getattr(vnode, "y_old", y_new)
             y_changed = y_new != y_old
+            if hasattr(vnode, "y_original") and y_new is None and y_old is None:
+                y_new = y_old = vnode.y_original
             if not self._can_set_label(y_new, y_old, repr(vnode)):
                 # Check unexpected situations.
                 # If skip_errors is False `self.check()` raises an exception.

--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -1,7 +1,7 @@
 """Feature extraction module."""
 from collections import defaultdict, OrderedDict
 import importlib
-from itertools import chain, islice, zip_longest
+from itertools import islice, zip_longest
 import logging
 from typing import (Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union)
 
@@ -263,8 +263,7 @@ class FeatureExtractor:
         self._log.debug("Parsed %d vnodes", sum(len(vn) for vn, _, _ in parsed_files))
         # filter composite labels by support
         if index_labels and self.cutoff_label_support > 0:
-            self._remove_labels_with_low_support(
-                chain.from_iterable(vn for vn, _, _ in parsed_files))
+            self._remove_labels_with_low_support([vn for vns, _, _ in parsed_files for vn in vns])
 
         files_vnodes_y = [[vnode for vnode in file_vnodes
                            if vnode.is_labeled_on_lines(file_lines)]
@@ -728,7 +727,7 @@ class FeatureExtractor:
             pos = node.end_position.offset
         return result, parents
 
-    def _remove_labels_with_low_support(self, vnodes: Iterable[VirtualNode]):
+    def _remove_labels_with_low_support(self, vnodes: Sequence[VirtualNode]) -> None:
         """
         Calculate the support for each label and discard those with too little value.
 

--- a/lookout/style/format/tests/test_postprocess.py
+++ b/lookout/style/format/tests/test_postprocess.py
@@ -20,9 +20,10 @@ class PostprocessingTests(unittest.TestCase):
         cls.language = "javascript"
         cls.data_service = FakeDataService(files=None, changes=None)
         cls.stub = cls.data_service.get_bblfsh()
+        config = {"global": {"feature_extractor": {"cutoff_label_support": 0}}}
         cls.fe = FeatureExtractor(
             language=cls.language,
-            **FormatAnalyzer._load_train_config({})[cls.language]["feature_extractor"])
+            **FormatAnalyzer._load_train_config(config)[cls.language]["feature_extractor"])
         cls.parent_loc = Path(__file__).parent.resolve()
         cls.base_dir_ = tempfile.TemporaryDirectory(dir=str(cls.parent_loc))
         cls.base_dir = cls.base_dir_.name


### PR DESCRIPTION
Depends on https://github.com/src-d/style-analyzer/pull/407

Both this methods relay that `y`-s in VirtualNode-s are the initial unfiltered targets. As soon as PR #407 make this filtering work we should fix these methods. 

Bug example for `FeatureExtractor._add_noops()`:
1. We filter `y` with value `⏎⏎⏎⏎⏎⏎⏎⏎⏎` and set it to `None`. `FeatureExtractor._add_noops()` see that `y=None` and adds NOOPs from both sides. 

Bug example for `CodeGenerator.gerenate()`:
2. We filter `y` with value `⏎⏎⏎␣⁻␣⁻␣⁻` and set `y=None`. Now we lose information about indentation change. Also `FeatureExtractor._add_noops()` inserts NOOPs between such VirtualNode and accumulated indentation. Both things confuse `CodeGenerator`.

So the main idea of PR is to add a new field to `VirtualNodes` called `y_original`. We set this field when any filtering is applied. 

PS: The fix is the ugliest one. And it is worth to include `y_original` to `VirtualNode.__init__()` feel free to ask me to do that if you have the same opinion.