### PR TITLE
Fix labels_to_class_sequences values type

### DIFF
--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -79,7 +79,8 @@ class FeatureExtractor:
         self.return_sibling_indices = return_sibling_indices
         self.selected_features = selected_features
         self.cutoff_label_support = cutoff_label_support
-        self.labels_to_class_sequences = label_composites if label_composites is not None else []
+        self.labels_to_class_sequences = list(map(tuple, label_composites)) \
+            if label_composites is not None else []
         self.class_sequences_to_labels = {
             tuple(l): i for i, l in enumerate(self.labels_to_class_sequences)}
         self.tokens = importlib.import_module("lookout.style.format.langs.%s.tokens" % language)

--- a/lookout/style/format/quality_report_noisy.py
+++ b/lookout/style/format/quality_report_noisy.py
@@ -168,7 +168,7 @@ def get_style_fixes(mispreds: Mapping[str, Misprediction], vnodes: Iterable[Virt
             continue
         for vn in vnodes:
             if vn.path == true_file and vn.start.offset >= mispred.node.start.offset:
-                if tuple(feature_extractor.labels_to_class_sequences[mispred.pred]) == vn.y:
+                if feature_extractor.labels_to_class_sequences[mispred.pred] == vn.y:
                     style_fixes.append(mispred)
                 break
     return style_fixes


### PR DESCRIPTION
I found out that we forget to convert `labels_to_class_sequences` values to tuples when we load it.

@warenlg I also remove conversion to `tuple` from your code because it should be always a tuple.

I experiensed problems in CodeGenerator when I try to convert label to class sequence: 
https://github.com/src-d/style-analyzer/blob/b5335fdff360d9bcffba8b84561dee8822b707d2/lookout/style/format/code_generator.py#L204