### PR TITLE
Restrict hyper-parameter search to base model

### DIFF
--- a/lookout/style/format/optimizer.py
+++ b/lookout/style/format/optimizer.py
@@ -1,0 +1,74 @@
+"""Optimize base model hyper-parameters."""
+from functools import partial
+from logging import getLogger
+from threading import Thread
+from typing import Any, Mapping, Optional, Tuple
+
+from lookout.core.slogging import logs_are_structured
+import numpy
+from scipy.optimize import OptimizeResult
+from scipy.sparse import csr_matrix
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score, StratifiedKFold
+from sklearn.tree import DecisionTreeClassifier
+from skopt import gp_minimize
+from skopt.space import Categorical, Integer
+from skopt.utils import use_named_args
+
+
+_dimensions = [
+    Categorical(name="base_model_name", categories=["sklearn.ensemble.RandomForestClassifier",
+                                                    "sklearn.tree.DecisionTreeClassifier"]),
+    Categorical(name="max_depth", categories=[None, 5, 10]),
+    Categorical(name="max_features", categories=[None, "auto"]),
+    Integer(name="min_samples_split", low=2, high=20),
+    Integer(name="min_samples_leaf", low=1, high=20),
+]
+
+
+class Optimizer:
+    """Optimize base model hyper-parameters."""
+
+    _log = getLogger("Optimizer")
+
+    def __init__(self, cv: int, n_iter: int, n_jobs: Optional[int], random_state: int):
+        """Construct an `Optimizer`."""
+        self.cv = cv
+        self.n_iter = max(10, n_iter)
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+
+    def optimize(self, X: csr_matrix, y: numpy.ndarray) -> Tuple[float, Mapping[str, Any]]:
+        """Conduct hyper-parameters search to find the best base model given the data."""
+        cost_function = use_named_args(_dimensions)(partial(self._cost, X=X, y=y))
+
+        def _minimize() -> OptimizeResult:
+            return gp_minimize(cost_function, _dimensions, n_calls=self.n_iter,
+                               random_state=self.random_state)
+
+        if not logs_are_structured:
+            # fool the check in joblib - everything still works without it
+            # this trick allows to run parallel bscv.fit()
+            from unittest.mock import patch
+            with patch("threading._MainThread", Thread):
+                self._log.debug("patched joblib")
+                res = _minimize()
+        else:
+            res = _minimize()
+        best_score = -res.fun
+        best_params = {dim.name: x for x, dim in zip(res.x, _dimensions)}
+        return best_score, best_params
+
+    def _cost(self, *, X: csr_matrix, y: numpy.ndarray, **params: Any) -> float:
+        params_copy = params.copy()
+        base_model_name = params_copy.pop("base_model_name")
+        if base_model_name == "sklearn.tree.DecisionTreeClassifier":
+            base_model_class = DecisionTreeClassifier
+        elif base_model_name == "sklearn.ensemble.RandomForestClassifier":
+            base_model_class = RandomForestClassifier
+            params_copy["n_estimators"] = 10
+            params_copy["n_jobs"] = -1
+        params_copy["random_state"] = self.random_state
+        base_model = base_model_class(**params_copy)
+        cv = StratifiedKFold(self.cv, random_state=self.random_state)
+        return -numpy.mean(cross_val_score(base_model, X, y, cv=cv, n_jobs=self.n_jobs))


### PR DESCRIPTION
@vmarkovtsev some context on why I set `prune_attributes` to `False` again:

In #426, we had the code:

```python
            backup_prune_attributes = lang_config["trainable_rules"]["prune_attributes"]
            lang_config["trainable_rules"]["prune_attributes"] = False
            try:
                # do hyperparam search and store result in bscv
            finally:
                lang_config["trainable_rules"]["prune_attributes"] = backup_prune_attributes
            # some more code
            lang_config["trainable_rules"].update(bscv.best_params_)
            trainable_rules = TrainableRules(**lang_config["trainable_rules"],
                                             origin_config=lang_config)
```
And the `.update(bscv.best_params_)` overrides the restoration of the original value of `prune_attributes` which means it's effectively always `False` during training.

Since I didn't use this code in this PR it was actually turned on and hanged in Travis (too long to compute). I think we should therefore turn it off before we find a better solution.