### PR TITLE
Save only on > 0 rules and raise exception for empty models

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -223,7 +223,10 @@ class FormatAnalyzer(Analyzer):
                 "\n\t".join("%-55s %.5E" % (fe.feature_names[i], importances[i])
                             for i in numpy.argsort(-importances)[:25] if importances[i] > 1e-5))
             # throw away imprecise classes
-            model[language] = trainable_rules.rules
+            if trainable_rules.rules.rules:
+                model[language] = trainable_rules.rules
+            else:
+                cls._log.warning("Model for %s had 0 rules. Skipping." % language)
         cls._log.info("trained %s", model)
         return model
 

--- a/lookout/style/format/rule_stat.py
+++ b/lookout/style/format/rule_stat.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, Mapping, MutableMapping, Union
 
 from bblfsh import BblfshClient
 import numpy
+from sklearn.exceptions import NotFittedError
 from tqdm import tqdm
 
 from lookout.style.format.benchmarks.time_profile import profile
@@ -105,6 +106,8 @@ def print_rules_report(input_pattern: str, bblfsh: str, language: str, model_pat
     """Print several different reports for a given model on a given dataset."""
     log = logging.getLogger("print_rules_report")
     model = FormatModel().load(model_path)
+    if language not in model:
+        raise NotFittedError()
     rules = model[language]
     print("Model parameters: %s" % rules.origin_config)
     print("Stats about rules: %s" % rules)

--- a/lookout/style/format/visualizer/server.py
+++ b/lookout/style/format/visualizer/server.py
@@ -11,6 +11,7 @@ from flask_cors import CORS
 from lookout.core.api.service_data_pb2 import File
 import numpy
 from scipy.sparse import csr_matrix
+from sklearn.exceptions import NotFittedError
 
 from lookout.style.format.descriptions import describe_rule_attrs, describe_sample
 from lookout.style.format.feature_extractor import FeatureExtractor
@@ -98,6 +99,8 @@ def return_features() -> Response:
     if res.status != 0:
         abort(500)
     model = FormatModel().load(str(Path(__file__).parent / "models" / "model.asdf"))
+    if language not in model:
+        raise NotFittedError()
     rules = model[language]
     file = File(content=code.encode(), uast=res.uast, language="javascript")
     config = rules.origin_config["feature_extractor"]


### PR DESCRIPTION
I'm not really familiar with all the latest developments in the report analyzers so at this point I only raised exceptions when trying to access inexistant rules. There are probably better specific tweaks that could be applied.