### PR TITLE
Make the rejected part of the PR curve light grey

### DIFF
--- a/lookout/style/format/templates/noisy_quality_report.md.jinja2
+++ b/lookout/style/format/templates/noisy_quality_report.md.jinja2
@@ -7,10 +7,10 @@
 
 ### Metrics table
 
-| repository |  number of mistakes  | recall at threshold precision | precision at max recall |   empirical confidence threshold   |    max recall     |        Number of rules (filtered / overall)          |
-|:----------:|:--------------------:|:-----------------------------:|:-----------------------:|:----------------------------------:|:-----------------:|:----------------------------------------------------:|
+| repository |  number of mistakes  | recall at threshold precision | precision at max recall |    empirical confidence threshold     |    max recall     |        Number of rules (filtered / overall)          |
+|:----------:|:--------------------:|:-----------------------------:|:-----------------------:|:-------------------------------------:|:-----------------:|:----------------------------------------------------:|
 {% for repo in repos %}
-|  {{repo}}  | {{n_mistakes[repo]}} |  {{rec_threshold_prec[repo]}} |  {{prec_max_rec[repo]}} | {{confidence_threshold_exp[repo]}} | {{max_rec[repo]}} | `{{ n_rules_filtered[repo] }} / {{ n_rules[repo] }}` |
+|  {{repo}}  | {{n_mistakes[repo]}} |  {{rec_threshold_prec[repo]}} |  {{prec_max_rec[repo]}} | {{confidence_threshold_exp[repo][1]}} | {{max_rec[repo]}} | `{{ n_rules_filtered[repo] }} / {{ n_rules[repo] }}` |
 {% endfor %}
 
 ### Precision-recall curves


### PR DESCRIPTION
Signed-off-by: Waren Long <waren@sourced.tech>

Fixed https://github.com/src-d/style-analyzer/issues/453

Makes the report look like this https://github.com/warenlg/style-analyzer/blob/add-reports/lookout/style/format/reports/report_noise.md