### PR TITLE
Split FixData to LineFix and FileFix

### DIFF
--- a/lookout/style/format/tests/test_comment_generation.py
+++ b/lookout/style/format/tests/test_comment_generation.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from lookout.style.format import descriptions, FormatAnalyzer
-from lookout.style.format.analyzer import FixData
+from lookout.style.format.analyzer import FileFix, LineFix
 from lookout.style.format.virtual_node import Position, VirtualNode
 
 
@@ -40,16 +40,17 @@ class CodeGeneratorTests(unittest.TestCase):
         line_number = 2
         suggested_code = "<new code line>"
         partial_backup = functools.partial
-        fix_data = FixData(
-            base_file=None, head_file=FakeHeadFile, confidence=100, line_number=line_number,
-            error="Failed to parse", language=language, feature_extractor=None,
-            winner_rules=[34], suggested_code=suggested_code, all_vnodes=[],
-            fixed_vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1),
-                                      value="!", y=(1,))])
+        line_fix = LineFix(
+            line_number=line_number, winner_rules=[34], suggested_code=suggested_code,
+            fixed_vnodes=[VirtualNode(start=Position(10, 2, 1), end=Position(12, 3, 1), value="!",
+                                      y=(1,))], confidence=100)
+        file_fix = FileFix(error="", line_fixes=[line_fix], language=language, base_file=None,
+                           feature_extractor=None, file_vnodes=[], head_file=FakeHeadFile)
+
         try:
 
             functools.partial = fake_partitial
-            text = analyzer.render_comment_text(fix_data)
+            text = analyzer.render_comment_text(file_fix, 0)
             res = """format: style mismatch:
 ```<language>
 1|<first code line>

--- a/lookout/style/format/tests/test_evaluate_smoke.py
+++ b/lookout/style/format/tests/test_evaluate_smoke.py
@@ -126,9 +126,9 @@ class EvaluateSmokeTests(unittest.TestCase):
                 index.write("\n".join(index_content[::3]))
             report_dir = os.path.join(outputpath, "report")
             evaluate_smoke_entry(outputpath, report_dir, None)
-            report_dir = pandas.read_csv(os.path.join(report_dir, "report.csv"))
-            self.assertEqual(len(report_dir), 11)
-            self.assertEqual(len(report_dir.columns), 15)
+            report = pandas.read_csv(os.path.join(report_dir, "report.csv"))
+            self.assertEqual(len(report), 11)
+            self.assertEqual(len(report.columns), 15)
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_quality_report.py
+++ b/lookout/style/format/tests/test_quality_report.py
@@ -23,6 +23,8 @@ class PretrainedModelTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Prepare environment & train the model for tests."""
+        if not server.exefile.exists():
+            server.fetch()
         # required config
         cls.bblfsh = "0.0.0.0:9432"
         cls.language = "javascript"
@@ -144,8 +146,9 @@ class QualityReportTests(PretrainedModelTests):
         output = "\n".join(output)
         output = output[:output.find("# Model report for https://github.com/jquery/jquery")]
         metrics = _get_precision_recall_f1_support(output)
-        self.assertEqual(
-            metrics, (0.8397747184701836, 0.8174414658975229, 0.7846189138709921, 2947))
+        self.assertAlmostEqual(
+            metrics, (0.8397747184701836, 0.8174414658975229, 0.7846189138709921, 2947),
+            delta=1e-15)
 
     def test_no_model(self):
         """Test on wrong path to model - expect fail."""


### PR DESCRIPTION
To solve the problem mentioned in https://github.com/src-d/style-analyzer/pull/478#issuecomment-447796005

TL;DR: now it is easy to process the file without comments. No need for an ad-hoc solution. 