### PR TITLE
Fix quote UAST check

### DIFF
--- a/lookout/style/format/analyzer.py
+++ b/lookout/style/format/analyzer.py
@@ -89,7 +89,7 @@ class FormatAnalyzer(Analyzer):
                 "random_state": 42,
             },
             "n_jobs": -1,
-            "n_iter": 5,
+            "n_iter": 10,
             "cv": 3,
             "line_length_limit": 500,
             "lower_bound_instances": 500,
@@ -284,13 +284,14 @@ class FormatAnalyzer(Analyzer):
             feature_extractor_output, bblfsh_stub: "bblfsh.aliases.ProtocolServiceStub",
             rules: Rules) -> Iterable[FixData]:
         X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = feature_extractor_output
-        y_pred, rule_winners, new_rules = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                                        feature_extractor=fe)
+        y_pred, rule_winners, new_rules, grouped_quote_predictions = rules.predict(
+            X=X, vnodes_y=vnodes_y, vnodes=vnodes, feature_extractor=fe)
         if self.config["uast_break_check"]:
             y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
                 y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={file.path: file},
                 feature_extractor=fe, stub=bblfsh_stub, vnode_parents=vnode_parents,
-                node_parents=node_parents, rule_winners=rule_winners, log=self._log)
+                node_parents=node_parents, rule_winners=rule_winners,
+                grouped_quote_predictions=grouped_quote_predictions)
         assert len(y) == len(y_pred)
         assert len(y) == len(rule_winners)
         code_generator = CodeGenerator(fe, skip_errors=True)

--- a/lookout/style/format/benchmarks/quality_report_noisy.py
+++ b/lookout/style/format/benchmarks/quality_report_noisy.py
@@ -104,12 +104,13 @@ def files2mispreds(files: Iterable[str], feature_extractor: FeatureExtractor, ru
     files = prepare_files(files, client, feature_extractor.language)
     X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = feature_extractor \
         .extract_features(files)
-    y_pred, rule_winners, _ = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                            feature_extractor=feature_extractor)
+    y_pred, rule_winners, _, grouped_quote_predictions = rules.predict(
+        X=X, vnodes_y=vnodes_y, vnodes=vnodes, feature_extractor=feature_extractor)
     y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
         y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes,
         files={f.path: f for f in files}, feature_extractor=feature_extractor, stub=client._stub,
-        vnode_parents=vnode_parents, node_parents=node_parents, rule_winners=rule_winners, log=log)
+        vnode_parents=vnode_parents, node_parents=node_parents, rule_winners=rule_winners,
+        grouped_quote_predictions=grouped_quote_predictions)
     mispreds = get_mispreds(y, y_pred, vnodes_y, rule_winners)
     return mispreds
 

--- a/lookout/style/format/classes.py
+++ b/lookout/style/format/classes.py
@@ -30,6 +30,7 @@ CLS_TO_STR = {
     CLS_TAB_INC: "\t",
 }
 INDEX_CLS_TO_STR = tuple(CLS_TO_STR[c] for c in CLASSES)
+
 _CLASS_REPRESENTATIONS_MAPPING = {
     CLS_DOUBLE_QUOTE: '"',
     CLS_NEWLINE: "⏎",

--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -15,7 +15,8 @@ from sklearn.feature_selection import SelectKBest, VarianceThreshold
 
 from lookout.style.format.classes import (
     CLASS_INDEX, CLASS_PRINTABLES, CLASS_REPRESENTATIONS, CLS_DOUBLE_QUOTE, CLS_NEWLINE, CLS_NOOP,
-    CLS_SINGLE_QUOTE, CLS_SPACE, CLS_SPACE_DEC, CLS_SPACE_INC, CLS_TAB, CLS_TAB_DEC, CLS_TAB_INC)
+    CLS_SINGLE_QUOTE, CLS_SPACE, CLS_SPACE_DEC, CLS_SPACE_INC, CLS_TAB, CLS_TAB_DEC, CLS_TAB_INC,
+    INDEX_CLS_TO_STR)
 from lookout.style.format.features import (  # noqa: F401
     Feature, FEATURE_CLASSES, FeatureGroup, FeatureId, FeatureLayout, Layout,
     MultipleValuesFeature, MutableFeatureLayout, MutableLayout)
@@ -359,6 +360,11 @@ class FeatureExtractor:
         """
         return ["".join(CLASS_PRINTABLES[label] for label in labels)
                 for labels in self.labels_to_class_sequences]
+
+    def label_to_str(self, label: int) -> str:
+        """Convert a label to string."""
+        return "".join(INDEX_CLS_TO_STR[cls]
+                       for cls in self.labels_to_class_sequences[label])
 
     def _create_neighbours(self, vnodes: Sequence[VirtualNode], vnodes_y: Sequence[VirtualNode],
                            parents: Mapping[int, bblfsh.Node],

--- a/lookout/style/format/optimizer.py
+++ b/lookout/style/format/optimizer.py
@@ -59,7 +59,7 @@ class Optimizer:
 
         def _minimize() -> OptimizeResult:
             return gp_minimize(cost_function, _dimensions, n_calls=self.n_iter,
-                               random_state=self.random_state)
+                               random_state=self.random_state, verbose=True)
 
         if not logs_are_structured:
             # fool the check in joblib - everything still works without it

--- a/lookout/style/format/postprocess.py
+++ b/lookout/style/format/postprocess.py
@@ -1,5 +1,5 @@
 """Postprocess predictions of the model."""
-from logging import Logger
+from logging import getLogger
 from typing import Dict, Mapping, MutableMapping, Optional, Sequence, Tuple  # noqa: F401
 
 import bblfsh
@@ -7,9 +7,12 @@ from lookout.core.api.service_data_pb2 import File
 from lookout.core.data_requests import parse_uast
 import numpy
 
-from lookout.style.format.classes import CLS_DOUBLE_QUOTE, CLS_SINGLE_QUOTE, INDEX_CLS_TO_STR
 from lookout.style.format.feature_extractor import FeatureExtractor
+from lookout.style.format.rules import QuotedNodeTripleMapping
 from lookout.style.format.virtual_node import VirtualNode
+
+
+_log = getLogger("Postprocess")
 
 
 def check_uasts_are_equal(uast1: bblfsh.Node, uast2: bblfsh.Node) -> bool:
@@ -39,8 +42,8 @@ def check_uasts_are_equal(uast1: bblfsh.Node, uast2: bblfsh.Node) -> bool:
 
 def _parse_code(parent: bblfsh.Node, content: str, stub: "bblfsh.aliases.ProtocolServiceStub",
                 parsing_cache: MutableMapping[int, Optional[Tuple[bblfsh.Node, int, int]]],
-                language: str, node_parents: Mapping[int, bblfsh.Node], logger: Logger,
-                path: str) -> Optional[Tuple[bblfsh.Node, int, int]]:
+                language: str, node_parents: Mapping[int, bblfsh.Node], path: str,
+                ) -> Optional[Tuple[bblfsh.Node, int, int]]:
     """
     Find a parent node that Babelfish can parse and parse it.
 
@@ -55,7 +58,6 @@ def _parse_code(parent: bblfsh.Node, content: str, stub: "bblfsh.aliases.Protoco
     :param parsing_cache: Cache to avoid the recomputation of the results for already seen nodes.
     :param language: language to use for Babelfish.
     :param node_parents: Parents mapping of the input UASTs.
-    :param logger: Logger.
     :param path: Path of the file being parsed.
     :return: Optional tuple of the parsed UAST and the corresponding starting and ending offsets.
     """
@@ -76,7 +78,7 @@ def _parse_code(parent: bblfsh.Node, content: str, stub: "bblfsh.aliases.Protoco
         current_ancestor = node_parents.get(id(current_ancestor), None)
     else:
         result = None
-        logger.warning("skipped file %s, due to errors in parsing the whole content", path)
+        _log.warning("skipped file %s, due to errors in parsing the whole content", path)
     for descendant in descendants:
         parsing_cache[id(descendant)] = result
     return result
@@ -87,7 +89,7 @@ def filter_uast_breaking_preds(
         vnodes: Sequence[VirtualNode], files: Mapping[str, File],
         feature_extractor: FeatureExtractor, stub: "bblfsh.aliases.ProtocolServiceStub",
         vnode_parents: Mapping[int, bblfsh.Node], node_parents: Mapping[int, bblfsh.Node],
-        rule_winners: numpy.ndarray, log: Logger,
+        rule_winners: numpy.ndarray, grouped_quote_predictions: QuotedNodeTripleMapping,
         ) -> Tuple[numpy.ndarray, numpy.ndarray, Sequence[VirtualNode], numpy.ndarray,
                    Sequence[int]]:
     """
@@ -104,35 +106,49 @@ def filter_uast_breaking_preds(
                            left and right babelfish nodes.
     :param node_parents: Parents mapping of the input UASTs.
     :param rule_winners: Numpy array of the index of the winning rule for each sample.
-    :param log: Logger.
+    :param grouped_quote_predictions: Quotes predictions (handled differenlty from the rest).
     :return: List of predictions indices that are considered valid i.e. that are not breaking
              the UAST.
     """
-    CLS_QUOTES = {CLS_SINGLE_QUOTE, CLS_DOUBLE_QUOTE}
     safe_preds = []
     current_path = None  # type: Optional[str]
     parsing_cache = {}  # type: Dict[int, Optional[Tuple[bblfsh.Node, int, int]]]
+    file_content = None  # type: Optional[str]
     cur_i = 0
     for i, (gt, pred, vn_y) in enumerate(zip(y, y_pred, vnodes_y)):
         if vn_y.path != current_path:
             parsing_cache = {}
             current_path = vn_y.path
+            file_content = files[vn_y.path].content.decode("utf-8", "replace")
         while vn_y is not vnodes[cur_i]:
             cur_i += 1
             if cur_i >= len(vnodes):
                 raise AssertionError("vnodes_y and vnodes are not consistent.")
+        # quote types are special cased
+        if id(vn_y) in grouped_quote_predictions:
+            pred_string = feature_extractor.label_to_str(pred)
+            group = grouped_quote_predictions[id(vn_y)]
+            # already handled with the previous vnode
+            if group is None:
+                continue
+            vnode1, vnode2, vnode3 = group
+            content_before = file_content[vn_y.start.offset:vn_y.end.offset]
+            content_after = (feature_extractor.label_to_str(y_pred[i]) + vnode2.value
+                             + feature_extractor.label_to_str(y_pred[i + 1]))
+            parsed_before, errors = parse_uast(stub, content_before, filename="",
+                                               language=feature_extractor.language)
+            if not errors:
+                parsed_after, errors = parse_uast(stub, content_after, filename="",
+                                                  language=feature_extractor.language)
+                if check_uasts_are_equal(parsed_before, parsed_after):
+                    safe_preds.extend((i, i + 1))
+            continue
         if gt == pred:
             safe_preds.append(i)
             continue
-        pred_string = "".join(INDEX_CLS_TO_STR[j] for j in
-                              feature_extractor.labels_to_class_sequences[pred])
-        # we don't filter predictions that are fixing quote types
-        if CLS_QUOTES.intersection(vn_y.value) and CLS_QUOTES.intersection(pred_string):
-            safe_preds.append(i)
-            continue
-        content_before = files[vn_y.path].content.decode("utf-8", "replace")
-        parsed_before = _parse_code(vnode_parents[id(vn_y)], content_before, stub, parsing_cache,
-                                    feature_extractor.language, node_parents, log, vn_y.path)
+        pred_string = feature_extractor.label_to_str(pred)
+        parsed_before = _parse_code(vnode_parents[id(vn_y)], file_content, stub, parsing_cache,
+                                    feature_extractor.language, node_parents, vn_y.path)
         if parsed_before is None:
             continue
         parent_before, start, end = parsed_before
@@ -145,13 +161,13 @@ def filter_uast_breaking_preds(
             # to handle mixed indentations, we include the `VirtualNode` following the predicted
             # one in the output predicted string, and start the rest of the sequence one
             # `VirtualNode` further to avoid its repetitions
-            content_after = content_before[:vn_y.start.offset] \
-                + output_pred \
-                + content_before[vn_y.start.offset + len(vn_y.value)
-                                 + len(vnodes[cur_i + 1].value):]
+            start_next_vnode = vn_y.start.offset + len(vn_y.value) + len(vnodes[cur_i + 1].value)
+            content_after = (file_content[:vn_y.start.offset]
+                             + output_pred
+                             + file_content[start_next_vnode:])
         # in case the prediction to check corresponds to the last label of a file
         except IndexError:
-            content_after = content_before[:vn_y.start.offset] \
+            content_after = file_content[:vn_y.start.offset] \
                 + output_pred
         content_after = content_after[start:end + diff_pred_offset]
         parent_after, errors_after = parse_uast(
@@ -159,7 +175,7 @@ def filter_uast_breaking_preds(
         if not errors_after:
             if check_uasts_are_equal(parent_before, parent_after):
                 safe_preds.append(i)
-    log.info("Non UAST breaking predictions: %d selected out of %d",
-             len(safe_preds), y_pred.shape[0])
+    _log.info("Non UAST breaking predictions: %d selected out of %d",
+              len(safe_preds), y_pred.shape[0])
     vnodes_y = [vn for i, vn in enumerate(list(vnodes_y)) if i in safe_preds]
     return y[safe_preds], y_pred[safe_preds], vnodes_y, rule_winners[safe_preds], safe_preds

--- a/lookout/style/format/rule_stat.py
+++ b/lookout/style/format/rule_stat.py
@@ -105,7 +105,6 @@ def generate_report(y: Union[numpy.ndarray, Iterable[Union[int, float]]],
 @profile
 def print_rules_report(input_pattern: str, bblfsh: str, language: str, model_path: str) -> None:
     """Print several different reports for a given model on a given dataset."""
-    log = logging.getLogger("print_rules_report")
     model = FormatModel().load(model_path)
     if language not in model:
         raise NotFittedError()
@@ -127,12 +126,13 @@ def print_rules_report(input_pattern: str, bblfsh: str, language: str, model_pat
         return
 
     X, y, (vnodes_y, vnodes, vnode_parents, node_parents) = res
-    y_pred, rule_winners, _ = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                            feature_extractor=fe)
+    y_pred, rule_winners, _, grouped_quote_predictions = rules.predict(
+        X=X, vnodes_y=vnodes_y, vnodes=vnodes, feature_extractor=fe)
     y, y_pred, vnodes_y, rule_winners, safe_preds = filter_uast_breaking_preds(
         y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={f.path: f for f in files},
         feature_extractor=fe, stub=client._stub, vnode_parents=vnode_parents,
-        node_parents=node_parents, rule_winners=rule_winners, log=log)
+        node_parents=node_parents, rule_winners=rule_winners,
+        grouped_quote_predictions=grouped_quote_predictions)
 
     print(generate_report(y=y, y_pred=y_pred, winners=rule_winners, feature_extractor=fe))
 

--- a/lookout/style/format/visualizer/server.py
+++ b/lookout/style/format/visualizer/server.py
@@ -110,12 +110,13 @@ def return_features() -> Response:
     if res is None:
         abort(500)
     X, y, (vnodes_y, vnodes, vnode_parents, node_parents, sibling_indices) = res
-    y_pred, rule_winners, rules = rules.predict(X=X, vnodes_y=vnodes_y, vnodes=vnodes,
-                                                feature_extractor=fe)
+    y_pred, rule_winners, rules, grouped_quote_predictions = rules.predict(
+        X=X, vnodes_y=vnodes_y, vnodes=vnodes, feature_extractor=fe)
     _, _, _, _, safe_preds = filter_uast_breaking_preds(
         y=y, y_pred=y_pred, vnodes_y=vnodes_y, vnodes=vnodes, files={file.path: file},
         feature_extractor=fe, stub=client._stub, vnode_parents=vnode_parents,
-        node_parents=node_parents, rule_winners=rule_winners, log=app.logger)
+        node_parents=node_parents, rule_winners=rule_winners,
+        grouped_quote_predictions=grouped_quote_predictions)
     break_uast = [False] * X.shape[0]
     for wrong_pred in set(range(X.shape[0])).difference(safe_preds):
         break_uast[wrong_pred] = True


### PR DESCRIPTION
This adds UAST check to quote predictions. Goal is to be able to detect stuff like `a = "'b'"` being changed to `a = ''b''` and breaking everything.