### PR TITLE
Fix repr(node)

### DIFF
--- a/lookout/style/format/virtual_node.py
+++ b/lookout/style/format/virtual_node.py
@@ -68,8 +68,8 @@ class VirtualNode:
         return self.value
 
     def __repr__(self) -> str:
-        return ("VirtualNode(\"%s\", y=%s, start=%s, end=%s, node=%s, path=\"%s\")" % (
-                    self.value.replace("\n", "\\n").replace("\t", "\\t"),
+        return ("VirtualNode(%s, y=%s, start=%s, end=%s, node=%s, path=\"%s\")" % (
+                    repr(self.value),
                     "None" if self.y is None else "".join(CLASS_REPRESENTATIONS[c]
                                                           for c in self.y),
                     tuple(self.start),


### PR DESCRIPTION
If `node.value` contains special character like `\r` it breaks `repr(node)`.
I suggest using byte representation for value.
With this fix `repr(node)` gives something like:
```
VirtualNode(b')', y=None, start=(29316, 1017, 2), end=(29317, 1017, 3), node=None, path="")
VirtualNode(b'(', y=None, start=(29317, 1017, 3), end=(29318, 1017, 4), node=None, path="")
VirtualNode(b')', y=None, start=(29318, 1017, 4), end=(29319, 1017, 5), node=None, path="")
VirtualNode(b';', y=None, start=(29319, 1017, 5), end=(29320, 1017, 6), node=None, path="")
VirtualNode(b'\r\n\r\n', y=None, start=(29320, 1017, 6), end=(29324, 1019, 1), node=None, path="")
```

before:
```
VirtualNode(")", y=None, start=(29316, 1017, 2), end=(29317, 1017, 3), node=None, path="")
VirtualNode("(", y=None, start=(29317, 1017, 3), end=(29318, 1017, 4), node=None, path="")
VirtualNode(")", y=None, start=(29318, 1017, 4), end=(29319, 1017, 5), node=None, path="")
VirtualNode(";", y=None, start=(29319, 1017, 5), end=(29320, 1017, 6), node=None, path="")
\n", y=None, start=(29320, 1017, 6), end=(29324, 1019, 1), node=None, path="")
```
(last line is broken)