### PR TITLE
Replace .split("\n") with .splitlines() in_classify_vnodes()

### DIFF
--- a/lookout/style/format/tests/test_features.py
+++ b/lookout/style/format/tests/test_features.py
@@ -99,7 +99,36 @@ class FeaturesTests(unittest.TestCase):
             if n.y is not None:
                 cls_counts.update(map(CLASSES.__getitem__, n.y))
             offset, line, col = n.end
+        self.assertEqual(len(self.contents), offset)
+        # New line ends on the next line
+        self.assertEqual(len(self.contents.splitlines()) + 1, line)
         self.assertEqual(cls_counts[CLS_SPACE_INC], cls_counts[CLS_SPACE_DEC])
+        self.assertGreater(cls_counts[CLS_SPACE_INC], 0)
+        self.assertGreater(cls_counts[CLS_SPACE], 0)
+        self.assertGreater(cls_counts[CLS_NEWLINE], 0)
+        self.assertGreater(cls_counts[CLS_SINGLE_QUOTE], 0)
+        self.assertTrue(cls_counts[CLS_SINGLE_QUOTE] % 2 == 0)
+
+    def test_classify_vnodes_with_trailing_space(self):
+        contents = self.contents + " "
+        nodes, _ = self.extractor._parse_file(contents, self.uast, "test_file")
+        nodes = list(self.extractor._classify_vnodes(nodes, "test_file"))
+        text = "".join(n.value for n in nodes)
+        self.assertEqual(text, contents)
+        cls_counts = Counter()
+        offset = line = col = 0
+        for n in nodes:
+            if line == n.start.line - 1:
+                line += 1
+                col = 1
+            self.assertEqual((offset, line, col), n.start, n.value)
+            if n.y is not None:
+                cls_counts.update(map(CLASSES.__getitem__, n.y))
+            offset, line, col = n.end
+        self.assertEqual(len(contents), offset)
+        # Space token always ends on the same line
+        self.assertEqual(len(contents.splitlines()), line)
+        self.assertEqual(cls_counts[CLS_SPACE_INC], cls_counts[CLS_SPACE_DEC] + 1)
         self.assertGreater(cls_counts[CLS_SPACE_INC], 0)
         self.assertGreater(cls_counts[CLS_SPACE], 0)
         self.assertGreater(cls_counts[CLS_NEWLINE], 0)

--- a/lookout/style/format/tests/test_quality_report.py
+++ b/lookout/style/format/tests/test_quality_report.py
@@ -147,11 +147,10 @@ class QualityReportTests(PretrainedModelTests):
         output = "\n".join(output)
         output = output[:output.find("# Model report for https://github.com/jquery/jquery")]
         metrics = _get_metrics(output)
-        expected_metrics = Metrics(precision=0.9830682401231401, ppcr=0.6611261872455902,
-                                   recall=0.9830682401231401, full_recall=0.649932157394844,
-                                   f1=0.9830682401231401, full_f1=0.7825199101490709,
-                                   support=1949, full_support=2948)
-
+        expected_metrics = Metrics(precision=0.9829633453794527, ppcr=0.6570556309362280,
+                                   recall=0.9829633453794527, full_recall=0.6458616010854816,
+                                   f1=0.9829633453794527, full_f1=0.7795291709314227,
+                                   support=1937, full_support=2948)
         assert_almost_equal(metrics, expected_metrics, decimal=15)
 
     def test_no_model(self):


### PR DESCRIPTION
This is the last part of `split -> splitlines` refactoring. 

This change nothing for a regular code but fixes processing for any weird Unicode newlines that is used in JS.