### PR TITLE
Rename eval-smoke-dataset parser variable and fix bblfsh arg

### DIFF
--- a/lookout/style/format/cmdline_tools.py
+++ b/lookout/style/format/cmdline_tools.py
@@ -133,24 +133,26 @@ def create_parser() -> ArgumentParser:
     )
 
     # Evaluate on different styles dataset
-    eval_gen_styles_parser = add_parser("eval-smoke-dataset",
+    eval_smoke_parser = add_parser("eval-smoke-dataset",
                                         "Evaluate on the dataset with different styles.")
-    eval_gen_styles_parser.set_defaults(handler=evaluate_smoke_entry)
-    eval_gen_styles_parser.add_argument(
+    eval_smoke_parser.set_defaults(handler=evaluate_smoke_entry)
+    eval_smoke_parser.add_argument(
         "inputpath", type=str,
         help="Path to the directory where the generated dataset is stored. "
              "To generate a dataset run gen-smoke-dataset command.")
-    eval_gen_styles_parser.add_argument(
+    eval_smoke_parser.add_argument(
         "reportdir", type=str,
         help="Path for report performance output directory.")
-    add_bblfsh_arg(eval_gen_styles_parser)
-    eval_gen_styles_parser.add_argument(
+    eval_smoke_parser.add_argument(
+        "--bblfsh",
+        help="Babelfish server's address.")
+    eval_smoke_parser.add_argument(
         "--train-config", type=json.loads, default="{}",
         help="Json config for train step.")
-    eval_gen_styles_parser.add_argument(
+    eval_smoke_parser.add_argument(
         "--analyze-config", type=json.loads, default="{}",
         help=" Json config for analyze step.")
-    eval_gen_styles_parser.add_argument(
+    eval_smoke_parser.add_argument(
         "--database", type=str, default=None,
         help="Path to the sqlite3 database with trained models metadata. "
              "Enables reusing previously trained models.")

--- a/lookout/style/format/cmdline_tools.py
+++ b/lookout/style/format/cmdline_tools.py
@@ -134,7 +134,7 @@ def create_parser() -> ArgumentParser:
 
     # Evaluate on different styles dataset
     eval_smoke_parser = add_parser("eval-smoke-dataset",
-                                        "Evaluate on the dataset with different styles.")
+                                   "Evaluate on the dataset with different styles.")
     eval_smoke_parser.set_defaults(handler=evaluate_smoke_entry)
     eval_smoke_parser.add_argument(
         "inputpath", type=str,

--- a/lookout/style/format/optimizer.py
+++ b/lookout/style/format/optimizer.py
@@ -16,8 +16,6 @@ from skopt.space import Categorical, Integer
 from skopt.utils import use_named_args
 
 
-
-
 class Optimizer:
     """Optimize base model hyper-parameters."""
 

--- a/lookout/style/format/tests/test_analyzer.py
+++ b/lookout/style/format/tests/test_analyzer.py
@@ -138,7 +138,7 @@ class AnalyzerTests(unittest.TestCase):
 
         def remove_uast(file):
             return FakeFile(path=file.path, content=file.content, uast=FakeUAST(),
-                        language="JavaScript")
+                            language="JavaScript")
 
         common = self.base_files.keys() & self.head_files.keys()
         self.data_service = FakeDataService(


### PR DESCRIPTION
The --bblfsh should not contain default value for smoke dataset evaluation because it blocks LOOKOUT_BBLFSHD environment variable usage. 
Without this change it is harder to use from docker container.