### PR TITLE
Remove global indentation from code generator

### DIFF
--- a/lookout/style/format/code_generator.py
+++ b/lookout/style/format/code_generator.py
@@ -76,7 +76,7 @@ class CodeGenerator:
         newline_index = CLASS_INDEX[CLS_NEWLINE]
         first_y = line_vnodes[0].y
 
-        generated = self.generate(line_vnodes, "local")
+        generated = self.generate(line_vnodes)
         if newline_index not in first_y:
             return generated
 
@@ -120,19 +120,16 @@ class CodeGenerator:
             result.append(vnode)
         return result
 
-    def generate(self, vnodes: Sequence[VirtualNode], indentation: str) -> str:
+    def generate(self, vnodes: Sequence[VirtualNode]) -> str:
         """
         Generate new source code from format model suggestions.
 
         :param vnodes: Sequence of all the `VirtualNode`-s corresponding to the input code file. \
                        Should be ordered by position.
-        :param indentation: Can be either "local" or "global"; in "local" mode \
-                            indentation changes do not propagate to the following lines.
         :return: New source code file content.
         """
-        assert indentation in ("local", "global")
         tokens = [""]
-        state = _State(change_locally=indentation == "local")
+        state = _State()
         for vnode in vnodes:
             y_new = vnode.y
             y_old = getattr(vnode, "y_old", y_new)
@@ -265,8 +262,7 @@ class CodeGenerator:
 
 
 class _State:
-    def __init__(self, change_locally: bool) -> None:
-        self.change_locally = change_locally
+    def __init__(self) -> None:
         self.indent_delta = 0
         self.indent_increase_tokens = []
         self.line_beginning = True
@@ -283,7 +279,7 @@ class _State:
         self.line_removed = (y_new is not None and
                              CodeGenerator.NEWLINE_INDEX not in y_new and
                              CodeGenerator.NEWLINE_INDEX in y_old)
-        if self.change_locally and not self.line_beginning:
+        if not self.line_beginning:
             self.indent_delta = 0
 
     def reset_indentation(self) -> None:

--- a/lookout/style/format/descriptions.py
+++ b/lookout/style/format/descriptions.py
@@ -267,7 +267,7 @@ def get_change_description(vnode: VirtualNode, feature_extractor: FeatureExtract
     new_label = class_representations[feature_extractor.class_sequences_to_labels[vnode.y]]
     if vnode.y[0] == CLASS_INDEX[CLS_NOOP]:
         if CLASS_INDEX[CLS_NEWLINE] in vnode.y_old:
-            return "Redundant line break. Please concatenate with previous line."
+            return "Redundant line break. Please concatenate with the previous line."
         else:
             return "%s at column %d should be removed." % (old_label, column)
     if vnode.y_old[0] == CLASS_INDEX[CLS_NOOP]:

--- a/lookout/style/format/tests/code_generator_data.py
+++ b/lookout/style/format/tests/code_generator_data.py
@@ -48,7 +48,7 @@ export default function flashToToast(flash) {
 }
 """
 
-# Virtual node index, new target (y) value, result, result for change_locally=True
+# Virtual node index, new target (y) value, result
 # if results are equal last can be omitted
 cases = OrderedDict([
     ("nothing changed", (
@@ -59,22 +59,6 @@ cases = OrderedDict([
     ("remove new line in the end of 4th line", (
         (22,),
         (labels_to_composite[(CLS_NOOP, )],),
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash).map(key => {
-    const messages = flash[key];
-    return messages.map(message => ({
-      message: message.msg,
-      type: key,
-      timeout: 5000
-    }));
-  })
-  .reduce((toasts, messages) => toasts.concat(messages), [])
-  .map(makeToast)
-  .map(({ payload }) => payload);
-}
-""",
         """import { makeToast } from '../../common/app/Toasts/redux';
 
 export default function flashToToast(flash) {
@@ -96,23 +80,6 @@ export default function flashToToast(flash) {
         (labels_to_composite[(CLS_SPACE_INC, )],),
         """ import { makeToast } from '../../common/app/Toasts/redux';
 
- export default function flashToToast(flash) {
-   return Object.keys(flash)
-     .map(key => {
-       const messages = flash[key];
-       return messages.map(message => ({
-         message: message.msg,
-         type: key,
-         timeout: 5000
-       }));
-     })
-     .reduce((toasts, messages) => toasts.concat(messages), [])
-     .map(makeToast)
-     .map(({ payload }) => payload);
- }
-""",
-        """ import { makeToast } from '../../common/app/Toasts/redux';
-
 export default function flashToToast(flash) {
   return Object.keys(flash)
     .map(key => {
@@ -132,23 +99,6 @@ export default function flashToToast(flash) {
         (15, 103),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC)],
          labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC)]),
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
- return Object.keys(flash)
-   .map(key => {
-     const messages = flash[key];
-     return messages.map(message => ({
-       message: message.msg,
-       type: key,
-       timeout: 5000
-     }));
-   })
-   .reduce((toasts, messages) => toasts.concat(messages), [])
-   .map(makeToast)
-   .map(({ payload }) => payload);
-}
-""",
         """import { makeToast } from '../../common/app/Toasts/redux';
 
 export default function flashToToast(flash) {
@@ -200,24 +150,6 @@ export default function flashToToast(flash) {
       const messages = flash[key];
       return messages
         .map(message => ({
-          message: message.msg,
-          type: key,
-          timeout: 5000
-        }));
-    })
-    .reduce((toasts, messages) => toasts.concat(messages), [])
-    .map(makeToast)
-    .map(({ payload }) => payload);
-}
-""",
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages
-        .map(message => ({
         message: message.msg,
         type: key,
         timeout: 5000
@@ -240,24 +172,6 @@ export default function flashToToast(flash) {
       const messages = flash[key];
       return messages
     .map(message => ({
-      message: message.msg,
-      type: key,
-      timeout: 5000
-    }));
-    })
-    .reduce((toasts, messages) => toasts.concat(messages), [])
-    .map(makeToast)
-    .map(({ payload }) => payload);
-}
-""",
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages
-    .map(message => ({
         message: message.msg,
         type: key,
         timeout: 5000
@@ -271,24 +185,6 @@ export default function flashToToast(flash) {
     ("new line in the middle of the 7th code line without indentation increase", (
         (39,),
         (labels_to_composite[(CLS_NEWLINE,)], ),
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages
-      .map(message => ({
-        message: message.msg,
-        type: key,
-        timeout: 5000
-      }));
-    })
-    .reduce((toasts, messages) => toasts.concat(messages), [])
-    .map(makeToast)
-    .map(({ payload }) => payload);
-}
-""",
         """import { makeToast } from '../../common/app/Toasts/redux';
 
 export default function flashToToast(flash) {
@@ -342,23 +238,6 @@ export default function flashToToast(flash) {
         type: key,
         timeout: 5000
         }));
-      })
-      .reduce((toasts, messages) => toasts.concat(messages), [])
-      .map(makeToast)
-      .map(({ payload }) => payload);
-  }
-""",
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages.map(message => ({
-        message: message.msg,
-        type: key,
-        timeout: 5000
-        }));
     })
     .reduce((toasts, messages) => toasts.concat(messages), [])
     .map(makeToast)
@@ -369,23 +248,6 @@ export default function flashToToast(flash) {
     ("change indentation decrease to indentation increase 11th line", (
         (60,),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_INC)],),
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages.map(message => ({
-        message: message.msg,
-        type: key,
-        timeout: 5000
-          }));
-        })
-        .reduce((toasts, messages) => toasts.concat(messages), [])
-        .map(makeToast)
-        .map(({ payload }) => payload);
-    }
-""",
         """import { makeToast } from '../../common/app/Toasts/redux';
 
 export default function flashToToast(flash) {
@@ -409,23 +271,6 @@ export default function flashToToast(flash) {
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_INC)],
          labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC,
                               CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC)]),
-        """import { makeToast } from '../../common/app/Toasts/redux';
-
-export default function flashToToast(flash) {
-  return Object.keys(flash)
-    .map(key => {
-      const messages = flash[key];
-      return messages.map(message => ({
-        message: message.msg,
-        type: key,
-        timeout: 5000
-          }));
-    })
-    .reduce((toasts, messages) => toasts.concat(messages), [])
-    .map(makeToast)
-    .map(({ payload }) => payload);
-}
-""",
         """import { makeToast } from '../../common/app/Toasts/redux';
 
 export default function flashToToast(flash) {

--- a/lookout/style/format/tests/test_evaluate_smoke.py
+++ b/lookout/style/format/tests/test_evaluate_smoke.py
@@ -130,7 +130,7 @@ class EvaluateSmokeTests(unittest.TestCase):
                                  get_train_config(), get_analyze_config())
             report = pandas.read_csv(os.path.join(report_dir, "report.csv"))
             self.assertEqual(len(report), 11)
-            self.assertEqual(len(report.columns), 15)
+            self.assertEqual(len(report.columns), 10)
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_utils.py
+++ b/lookout/style/format/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from lookout.style.format.utils import flatten_dict, merge_dicts
+from lookout.style.format.utils import merge_dicts
 
 
 class RulesMergeDicts(unittest.TestCase):
@@ -32,17 +32,6 @@ class RulesMergeDicts(unittest.TestCase):
         d3 = dict(b={"c": 3}, d=4)
         res = dict(a=1, b={"c": 3}, d=4)
         self.assertEqual(merge_dicts(d1, d2, d3), res)
-
-    def test_flatten_dict(self):
-        cases = [
-            ({"1": 1, "2": 2}, {"1": 1, "2": 2}),
-            ({"1": 1, "2": {"3": 3, "4": 4}}, {"1": 1, "2_3": 3, "2_4": 4}),
-            ({"1": 1, "2": {"3": 3, "4": {"5": 5, "6": 6}}},
-             {"1": 1, "2_3": 3, "2_4_5": 5, "2_4_6": 6}),
-        ]
-
-        for d, res in cases:
-            self.assertEqual(flatten_dict(d), res)
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/utils.py
+++ b/lookout/style/format/utils.py
@@ -111,30 +111,6 @@ def merge_dicts(*dicts: Mapping) -> dict:
     return res
 
 
-def flatten_dict(d: Dict[str, Any], level_separator: str="_") -> Dict[str, Any]:
-    """
-    Convert nested dictionaries with string keys into one flat dict.
-
-    Example:
-    >>> a = {"1": 1, "2": {"3": 3, "4": 4}}
-    >>> flatten_dict(a)
-    >>> {"1": 1, "2_3": 3, "2_4": 4}}
-
-    :param d: Dictionary to flatten.
-    :param level_separator: String separator between names of different level.
-    :return: new Flat Dictionary
-    """
-    res = dict()
-    queue = list(d.items())
-    while queue:
-        key, val = queue.pop(0)
-        if not isinstance(val, dict):
-            res[key] = val
-        else:
-            queue.extend((key+level_separator+cur_key, val[cur_key]) for cur_key in val)
-    return res
-
-
 def generate_comment(filename: str, confidence: int, line: int, text: str) -> Comment:
     """
     Generate comment.


### PR DESCRIPTION
Related to https://github.com/src-d/style-analyzer/issues/522

So we thought that this change helps us to simplify the code of `CodeGenerator` class. But as I find out it is not so easy because we still need quite a lot of logic to process indentation changes carefully. 

To simplify the code I should implement https://github.com/src-d/style-analyzer/issues/523 first. And this helps a lot to simplify `CodeGenerator`.

But this part can be merged now. 