### PR TITLE
Join accumulated indentation token to previous one. Refactor CodeGenerator. Split quotes to separate vnode.

### DIFF
--- a/lookout/style/format/classes.py
+++ b/lookout/style/format/classes.py
@@ -17,6 +17,7 @@ CLASSES = (CLS_SPACE, CLS_TAB, CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_DEC,
 CLASS_INDEX = {cls: i for i, cls in enumerate(CLASSES)}
 EMPTY_CLS = frozenset([CLASS_INDEX[CLS_TAB_DEC], CLASS_INDEX[CLS_SPACE_DEC],
                        CLASS_INDEX[CLS_NOOP]])
+QUOTES_INDEX = {CLASS_INDEX[x] for x in [CLS_SINGLE_QUOTE, CLS_DOUBLE_QUOTE]}
 CLS_TO_STR = {
     CLS_DOUBLE_QUOTE: '"',
     CLS_NEWLINE: "\n",  # FIXME(zurk) Not usable for \r\n endings

--- a/lookout/style/format/classes.py
+++ b/lookout/style/format/classes.py
@@ -19,7 +19,7 @@ EMPTY_CLS = frozenset([CLASS_INDEX[CLS_TAB_DEC], CLASS_INDEX[CLS_SPACE_DEC],
                        CLASS_INDEX[CLS_NOOP]])
 CLS_TO_STR = {
     CLS_DOUBLE_QUOTE: '"',
-    CLS_NEWLINE: "\n",
+    CLS_NEWLINE: "\n",  # FIXME(zurk) Not usable for \r\n endings
     CLS_NOOP: "",
     CLS_SINGLE_QUOTE: "'",
     CLS_SPACE: " ",

--- a/lookout/style/format/code_generator.py
+++ b/lookout/style/format/code_generator.py
@@ -75,11 +75,15 @@ class CodeGenerator:
         if not line_vnodes:
             return ""
 
-        newline_index = CLASS_INDEX[CLS_NEWLINE]
         first_y = line_vnodes[0].y
 
         generated = self.generate(line_vnodes)
-        if newline_index not in first_y:
+        if line_vnodes[0].y is None:
+            # we add " " because we want to count probably empty last line
+            lines_no = len((line_vnodes[0].value + " ").splitlines())
+            return "".join(generated.splitlines()[lines_no:])
+
+        if first_y is not None and self.NEWLINE_INDEX not in first_y:
             return generated
 
         # First line is always removed because it is an end line from the previous line.
@@ -89,9 +93,9 @@ class CodeGenerator:
                 # Line is not empty
                 break
         lines_num = 0
-        if line_vnodes and hasattr(line_vnodes[0], "y_old") and newline_index in first_y:
-            lines_num = line_vnodes[0].y.count(newline_index) - \
-                        line_vnodes[0].y_old.count(newline_index)
+        if line_vnodes and hasattr(line_vnodes[0], "y_old") and self.NEWLINE_INDEX in first_y:
+            lines_num = line_vnodes[0].y.count(self.NEWLINE_INDEX) - \
+                        line_vnodes[0].y_old.count(self.NEWLINE_INDEX)
         return "".join(generated_lines[i - max(0, lines_num):])
 
     def apply_predicted_y(self, vnodes: Sequence[VirtualNode],

--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -570,7 +570,7 @@ class FeatureExtractor:
         """
         start, end, value, current_class_seq = None, None, "", []
         for vnode in vnodes:
-            if vnode.y is None:
+            if vnode.y is None and not vnode.is_accumulated_indentation:
                 if current_class_seq:
                     yield VirtualNode(value=value, start=start, end=end,
                                       y=tuple(current_class_seq), path=path)
@@ -581,7 +581,8 @@ class FeatureExtractor:
                     start = vnode.start
                 end = vnode.end
                 value += vnode.value
-                current_class_seq.extend(vnode.y)
+                if not vnode.is_accumulated_indentation:
+                    current_class_seq.extend(vnode.y)
         if current_class_seq:
             assert value
             yield VirtualNode(value=value, start=start, end=end, y=tuple(current_class_seq),
@@ -606,7 +607,7 @@ class FeatureExtractor:
                                                 end=Position(0, 1, 1), y=noop_label, path=path))
         for vnode, next_vnode in zip(vnodes, islice(vnodes, 1, None)):
             augmented_vnodes.append(vnode)
-            if vnode.y is None and not vnode.is_accumulated_indentation and next_vnode.y is None:
+            if vnode.y is None and next_vnode.y is None:
                 augmented_vnodes.append(VirtualNode(value="", start=vnode.end, end=vnode.end,
                                                     y=noop_label, path=path))
         augmented_vnodes.append(next_vnode)

--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -16,7 +16,7 @@ from sklearn.feature_selection import SelectKBest, VarianceThreshold
 from lookout.style.format.classes import (
     CLASS_INDEX, CLASS_PRINTABLES, CLASS_REPRESENTATIONS, CLS_DOUBLE_QUOTE, CLS_NEWLINE, CLS_NOOP,
     CLS_SINGLE_QUOTE, CLS_SPACE, CLS_SPACE_DEC, CLS_SPACE_INC, CLS_TAB, CLS_TAB_DEC, CLS_TAB_INC,
-    INDEX_CLS_TO_STR)
+    INDEX_CLS_TO_STR, QUOTES_INDEX)
 from lookout.style.format.features import (  # noqa: F401
     Feature, FEATURE_CLASSES, FeatureGroup, FeatureId, FeatureLayout, Layout,
     MultipleValuesFeature, MutableFeatureLayout, MutableLayout)
@@ -570,7 +570,9 @@ class FeatureExtractor:
         """
         start, end, value, current_class_seq = None, None, "", []
         for vnode in vnodes:
-            if vnode.y is None and not vnode.is_accumulated_indentation:
+            if vnode.y is None and not vnode.is_accumulated_indentation or (
+                vnode.y is not None and vnode.y[0] in QUOTES_INDEX
+            ):
                 if current_class_seq:
                     yield VirtualNode(value=value, start=start, end=end,
                                       y=tuple(current_class_seq), path=path)

--- a/lookout/style/format/tests/code_generator_data.py
+++ b/lookout/style/format/tests/code_generator_data.py
@@ -57,7 +57,7 @@ cases = OrderedDict([
         original_code,
     )),
     ("remove new line in the end of 4th line", (
-        (22,),
+        (23,),
         (labels_to_composite[(CLS_NOOP, )],),
         """import { makeToast } from '../../common/app/Toasts/redux';
 
@@ -96,7 +96,7 @@ export default function flashToToast(flash) {
 }
 """)),
     ("remove indentation in the 4th line till the end", (
-        (15, 103),
+        (16, 104),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC)],
          labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC)]),
         """import { makeToast } from '../../common/app/Toasts/redux';
@@ -117,7 +117,7 @@ export default function flashToToast(flash) {
  }
 """)),
     ("new line between 6th and 7th regular code lines", (
-        (37,),
+        (38,),
         (labels_to_composite[(CLS_NEWLINE, CLS_NEWLINE)], ),
         """import { makeToast } from '../../common/app/Toasts/redux';
 
@@ -138,7 +138,7 @@ export default function flashToToast(flash) {
 }
 """)),
     ("new line in the middle of the 7th code line with indentation increase", (
-        (39, 64),
+        (40, 65),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_INC)],
          labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC,
                               CLS_SPACE_DEC, CLS_SPACE_DEC)]),
@@ -161,7 +161,7 @@ export default function flashToToast(flash) {
 }
 """)),
     ("new line in the middle of the 7th code line with indentation decrease", (
-        (39, 64),
+        (40, 65),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC)],
          labels_to_composite[(CLS_NEWLINE, )]),
         """import { makeToast } from '../../common/app/Toasts/redux';
@@ -183,7 +183,7 @@ export default function flashToToast(flash) {
 }
 """)),
     ("new line in the middle of the 7th code line without indentation increase", (
-        (39,),
+        (40,),
         (labels_to_composite[(CLS_NEWLINE,)], ),
         """import { makeToast } from '../../common/app/Toasts/redux';
 
@@ -204,8 +204,8 @@ export default function flashToToast(flash) {
 }
 """)),
     ("change quotes", (
-        (5, 6),
-        (labels_to_composite[(CLS_SPACE, CLS_DOUBLE_QUOTE)],
+        (6, 7),
+        (labels_to_composite[(CLS_DOUBLE_QUOTE,)],
          labels_to_composite[(CLS_DOUBLE_QUOTE,)]),
         """import { makeToast } from "../../common/app/Toasts/redux";
 
@@ -225,7 +225,7 @@ export default function flashToToast(flash) {
 }
 """)),
     ("remove indentation decrease 11th line", (
-        (60,),
+        (61,),
         (labels_to_composite[(CLS_NEWLINE,)],),
         """import { makeToast } from '../../common/app/Toasts/redux';
 
@@ -246,7 +246,7 @@ export default function flashToToast(flash) {
 """,
     )),
     ("change indentation decrease to indentation increase 11th line", (
-        (60,),
+        (61,),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_INC)],),
         """import { makeToast } from '../../common/app/Toasts/redux';
 
@@ -267,7 +267,7 @@ export default function flashToToast(flash) {
 """,
     )),
     ("change indentation decrease to indentation increase 11th line but keep the rest", (
-        (60, 64),
+        (61, 65),
         (labels_to_composite[(CLS_NEWLINE, CLS_SPACE_INC, CLS_SPACE_INC)],
          labels_to_composite[(CLS_NEWLINE, CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC,
                               CLS_SPACE_DEC, CLS_SPACE_DEC, CLS_SPACE_DEC)]),

--- a/lookout/style/format/tests/test_postprocess.py
+++ b/lookout/style/format/tests/test_postprocess.py
@@ -10,7 +10,7 @@ import numpy
 
 from lookout.style.format.analyzer import FormatAnalyzer
 from lookout.style.format.classes import (
-    CLASS_INDEX, CLS_DOUBLE_QUOTE, CLS_NOOP, CLS_SINGLE_QUOTE, CLS_SPACE)
+    CLASS_INDEX, CLS_DOUBLE_QUOTE, CLS_NOOP, CLS_SINGLE_QUOTE)
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.postprocess import filter_uast_breaking_preds
 from lookout.style.format.tests.test_analyzer import FakeDataService
@@ -81,12 +81,12 @@ class PostprocessingTests(unittest.TestCase):
 
     def test_bad_and_good_quotes(self):
         self.edit_and_test("""var a = '"0"'; var c = "0";""",
-                           {3: (CLS_SPACE, CLS_DOUBLE_QUOTE), 4: (CLS_DOUBLE_QUOTE,),
-                            8: (CLS_SPACE, CLS_SINGLE_QUOTE), 9: (CLS_SINGLE_QUOTE,)},
-                           quote_indices=(3, 8), bad_indices=frozenset((3, 4)))
+                           {4: (CLS_DOUBLE_QUOTE), 5: (CLS_DOUBLE_QUOTE,),
+                            10: (CLS_SINGLE_QUOTE), 11: (CLS_SINGLE_QUOTE,)},
+                           quote_indices=(4, 10), bad_indices=frozenset((4, 5)))
 
     def test_lonely_quote(self):
-        self.edit_and_test("var a = 0; var b = 'c';", {2: (CLS_SINGLE_QUOTE)}, quote_indices=(8,))
+        self.edit_and_test("var a = 0; var b = 'c';", {2: (CLS_SINGLE_QUOTE)}, quote_indices=(9,))
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_quality_report.py
+++ b/lookout/style/format/tests/test_quality_report.py
@@ -148,10 +148,10 @@ class QualityReportTests(PretrainedModelTests):
         self.assertEqual(qcount, 1)
         output = output[:output.find("# Model report for")]
         metrics = _get_metrics(output)
-        expected_metrics = (0.9756371814092953, 0.9756371814092953,
-                            0.8856753997958490, 0.9756371814092953,
-                            0.9284822543249510, 0.9077917659067710,
-                            2668, 2939)
+        expected_metrics = (0.9292385057471264, 0.9292385057471264,
+                            0.8507070042749095, 0.9292385057471263,
+                            0.8882403433476395, 0.9154883262084841,
+                            2784, 3041)
         assert_almost_equal(metrics, expected_metrics, decimal=15)
 
     def test_no_model(self):


### PR DESCRIPTION
PR is based on https://github.com/src-d/style-analyzer/pull/584

Closes https://github.com/src-d/style-analyzer/issues/522
Closes https://github.com/src-d/style-analyzer/issues/523
**UPD**: Closes https://github.com/src-d/style-analyzer/issues/579

The code generator is mostly rewritten and simplified. It was not possible if we keep accumulated indentation token separately, so I merge it as was mentioned in #523.

@m09 I think this change should not affect your visualizer or any other part of the code but I want additional confirmation just in case.

**UPD**: as soon as I did it (without 3rd commit), I get some undesirable effect. 
Let's considet next code:
```javascript
list = [
  "a1",
  "a2",
]
```
We have next vnodes there (`!` means accumulated indentation token):
```
list␣=␣[
⏎␣⁺␣⁺"a1",
⏎!"a2",
⏎␣⁻␣⁻]
```

I merge accumulated indentation token (2 spaces) on 3rd line with `\n  ` token. But this token prevents next token `"` to be merged with `⏎`. What was bad is that we do merge `"` on the second line because there is no accumulated indentation token in between. I fix it and do not merge quotes to the other tokens. This change also affects the quality.