### PR TITLE
Add quality reports comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-#Mac files
+# Mac files
 *.DS_Store
+
+# Temporary reports
+lookout/style/format/benchmarks/reports/untagged/
 
 .idea
 # Byte-compiled / optimized / DLL files

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bblfsh-start:
 	docker exec style_analyzer_bblfshd bblfshctl driver install \
 		javascript docker://bblfsh/javascript-driver\:v1.2.0
 
-REPORTS_DIR ?= reports
+REPORTS_DIR ?= $(current_dir)/lookout/style/format/benchmarks/reports
 REPORT_VERSION ?= untagged
 REPORT_DIR ?= $(REPORTS_DIR)/$(REPORT_VERSION)
 SMOKE_REPORT_DIR ?= $(REPORT_DIR)/js_smoke
@@ -50,6 +50,7 @@ QUALITY_REPORT_DIR ?= $(REPORT_DIR)/quality
 SMOKE_INIT ?= ./lookout/style/format/benchmarks/data/js_smoke_init.tar.xz
 QUALITY_REPORT_REPOS ?= ./lookout/style/format/benchmarks/data/quality_report_repos.csv
 QUALITY_REPORT_REPOS_WITH_VNODE ?= ./lookout/style/format/benchmarks/data/quality_report_repos_with_vnodes_number.csv
+BASE_REPORT_VERSION ?= 0.1.0
 
 $(SMOKE_REPORT_DIR) $(NOISY_REPORT_DIR) $(QUALITY_REPORT_DIR):
 	mkdir -p $@
@@ -64,6 +65,14 @@ report-noisy: $(NOISY_REPORT_DIR)
 report-quality: $(QUALITY_REPORT_DIR)
 	python3 -m lookout.style.format.benchmarks.top_repos_quality -o $(QUALITY_REPORT_DIR) \
 		-i $(QUALITY_REPORT_REPOS_WITH_VNODE) 2>&1 | tee $(QUALITY_REPORT_DIR)/logs.txt
+report-compare:
+	python3 -m lookout.style.format compare-quality \
+		--base $(REPORTS_DIR)/$(BASE_REPORT_VERSION)/quality/summary-train_report.md \
+		--new $(QUALITY_REPORT_DIR)/summary-train_report.md -o -
+	python3 -m lookout.style.format compare-quality \
+		--base $(REPORTS_DIR)/$(BASE_REPORT_VERSION)/quality/summary-test_report.md \
+		--new $(QUALITY_REPORT_DIR)/summary-test_report.md -o -
+
 report-release: report-smoke report-noisy report-quality
 
 expected-vnodes-number:

--- a/lookout/style/format/benchmarks/compare_quality_reports.py
+++ b/lookout/style/format/benchmarks/compare_quality_reports.py
@@ -1,0 +1,94 @@
+import sys
+from typing import TextIO, Union
+
+import pandas
+from tabulate import tabulate
+
+from lookout.style.format.benchmarks.top_repos_quality import FLOAT_PRECISION
+
+
+_column_formats = {
+    "precision": FLOAT_PRECISION,
+    "recall": FLOAT_PRECISION,
+    "full_recall": FLOAT_PRECISION,
+    "f1": FLOAT_PRECISION,
+    "full_f1": FLOAT_PRECISION,
+    "ppcr": FLOAT_PRECISION,
+    "support": "7g",
+    "full_support": "7g",
+    "Rules Number": "4g",
+    "Average Rule Len": ".1f",
+}
+
+
+def _convert_cell_to_value(cell: str) -> Union[int, float, str]:
+    for type_ in (int, float):
+        try:
+            return type_(cell.strip())
+        except ValueError:
+            pass
+    cell = cell.strip()
+    return cell if cell else float("nan")
+
+
+def _quality_report_table_to_df(report_table_file: TextIO) -> pandas.DataFrame:
+    table = []
+    separator_set = frozenset(":|-")
+    for line in report_table_file:
+        if set(line.strip()) <= separator_set:
+            continue
+        cells = line.strip().split("|")
+        if not cells[0]:
+            cells = cells[1:]
+        if not cells[-1]:
+            cells = cells[:-1]
+        values = [_convert_cell_to_value(c) for c in cells]
+        table.append(values)
+    return pandas.DataFrame(table[1:], columns=table[0])
+
+
+def compare_quality_reports(base: TextIO, new: TextIO, output: TextIO) -> None:
+    """
+    Print a table with metric difference between the reports.
+
+    :param base: Baseline report file. Usually the latest report from ./report/ directory.
+    :param new: New report file. Usually It is a report generated for master or any local \
+                change you did and want to validate.
+    :param output: The result will be saved to this file.
+    """
+    base_report = _quality_report_table_to_df(base)
+    new_report = _quality_report_table_to_df(new)
+    base_report.set_index("repo", inplace=True)
+    new_report.set_index("repo", inplace=True)
+    delta = new_report - base_report
+    delta = delta.reindex(index=list(base_report.index))
+    for field in delta.columns:
+        delta[field] = new_report[field].map(lambda x: ("%%%s" % _column_formats[field] % x)) + \
+                       delta[field].map(lambda x: " (%%+%s)" % _column_formats[field] % x)
+
+    delta = delta.fillna("")
+    delta.loc[["weighted average"],
+              ["support", "full_support", "Rules Number", "Average Rule Len"]] = ""
+
+    res = "\n# Report comparison\n%s\nvs\n%s\n\n" % (new, base) \
+          + tabulate(delta, tablefmt="pipe", headers="keys", stralign="right")
+    print(res, file=output)
+
+
+def compare_quality_reports_entry(base: str, new: str, output: str) -> None:
+    """
+    Print a table with metric difference between the reports.
+
+    Command line entry point for compare_quality_reports().
+
+    :param base: Baseline report file path. Usually the latest report from ./report/ directory.
+    :param new: New report file path. Usually It is a report generated for master or any local \
+                change you did and want to validate.
+    :param output: The result will be saved to this file or print to stdout if you set `-`.
+    """
+    with open(base) as base_file, open(new) as new_file:
+        if output == "-":
+            compare_quality_reports(base_file, new_file, sys.stdout)
+        else:
+            with open(output, "w") as output_file:
+                compare_quality_reports(base_file, new_file, output_file)

--- a/lookout/style/format/cmdline_tools.py
+++ b/lookout/style/format/cmdline_tools.py
@@ -79,6 +79,8 @@ def create_parser() -> ArgumentParser:
     :return: an ArgumentParser with an handler defined in the handler attribute.
     """
     # Deferred imports to speed up loading __init__
+    from lookout.style.format.benchmarks.compare_quality_reports import \
+        compare_quality_reports_entry
     from lookout.style.format.benchmarks.evaluate_smoke import evaluate_smoke_entry
     from lookout.style.format.benchmarks.generate_smoke import generate_smoke_entry
     from lookout.style.format.benchmarks.general_report import print_reports
@@ -131,6 +133,22 @@ def create_parser() -> ArgumentParser:
         "--retrain", action="store_true", default=False,
         help="Force model retraining")
 
+    # Compare two quality reports summaries
+    compare_quality_parser = add_parser(
+        "compare-quality",
+        "Creates a file with the differences in quality metrics between two reports.")
+    compare_quality_parser.set_defaults(handler=compare_quality_reports_entry)
+    compare_quality_parser.add_argument(
+        "--base", type=str, required=True,
+        help="Baseline report. Usually the latest report from ./report/ directory.")
+    compare_quality_parser.add_argument(
+        "--new", type=str, required=True,
+        help="New report. Usually It is a report generated for master or any local \
+                       change you did and want to validate.")
+    compare_quality_parser.add_argument(
+        "-o", "--output", type=str, required=True,
+        help="Path to the file to save result or - to print to stdout.")
+
     # Generate dataset of different styles in code for smoke testing.
     gen_smoke_parser = add_parser("gen-smoke-dataset",
                                   "Generate dataset with different styles. "
@@ -145,8 +163,7 @@ def create_parser() -> ArgumentParser:
         help="Path to the directory where the generated dataset should be stored.")
     gen_smoke_parser.add_argument(
         "--force", default=False, action="store_true",
-        help="Override output directory if exists.",
-    )
+        help="Override output directory if exists.")
 
     # Evaluate on different styles dataset
     eval_smoke_parser = add_parser("eval-smoke-dataset",

--- a/lookout/style/format/tests/test_compare_quality_reports.py
+++ b/lookout/style/format/tests/test_compare_quality_reports.py
@@ -1,0 +1,45 @@
+import tempfile
+import unittest
+
+from lookout.style.format.benchmarks.compare_quality_reports import compare_quality_reports_entry
+
+report1 = """
+| repo               |   precision |   recall |   full_recall |    f1 |   full_f1 |   ppcr |   support |   full_support |   Rules Number |   Average Rule Len |
+|:-------------------|------------:|---------:|--------------:|------:|----------:|-------:|----------:|---------------:|---------------:|-------------------:|
+| telescope          |       1.000 |    1.000 |         0.166 | 1.000 |     0.284 |  0.166 |       121 |            731 |              2 |                2.0 |
+| weighted average   |       0.971 |    0.971 |         0.909 | 0.971 |     0.938 |  0.939 |           |                |                |                    |
+""".strip()  # noqa E501
+
+report2 = """
+| repo               |   precision |   recall |   full_recall |    f1 |   full_f1 |   ppcr |   support |   full_support |   Rules Number |   Average Rule Len |
+|:-------------------|------------:|---------:|--------------:|------:|----------:|-------:|----------:|---------------:|---------------:|-------------------:|
+| telescope          |       1.000 |    1.000 |         0.166 | 1.000 |     0.284 |  0.166 |       121 |            731 |              2 |                2.0 |
+| weighted average   |       0.971 |    0.971 |         0.909 | 0.971 |     0.938 |  0.939 |           |                |                |                    |
+""".strip()  # noqa E501
+
+diff_report = """
+|             repo |      precision |         recall |    full_recall |             f1 |        full_f1 |           ppcr |       support |   full_support |   Rules Number |   Average Rule Len |
+|-----------------:|---------------:|---------------:|---------------:|---------------:|---------------:|---------------:|--------------:|---------------:|---------------:|-------------------:|
+|        telescope | 1.000 (+0.000) | 1.000 (+0.000) | 0.166 (+0.000) | 1.000 (+0.000) | 0.284 (+0.000) | 0.166 (+0.000) | 121 (     +0) |  731 (     +0) |       2 (  +0) |         2.0 (+0.0) |
+| weighted average | 0.971 (+0.000) | 0.971 (+0.000) | 0.909 (+0.000) | 0.971 (+0.000) | 0.938 (+0.000) | 0.939 (+0.000) |               |                |                |                    |
+""".strip()  # noqa E501
+
+
+class EvaluateSmokeTests(unittest.TestCase):
+    def test_compare_quality_reports_entry(self):
+        self.maxDiff = None
+        with tempfile.NamedTemporaryFile() as f_res:
+            with tempfile.NamedTemporaryFile() as f1:
+                with tempfile.NamedTemporaryFile() as f2:
+                    with open(f1.name, "w") as f:
+                        f.write(report1)
+                    with open(f2.name, "w") as f:
+                        f.write(report2)
+                    compare_quality_reports_entry(f1.name, f2.name, f_res.name)
+            with open(f_res.name) as f:
+                res = f.read()
+        self.assertEqual("\n".join(res.splitlines()[-4:]), diff_report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lookout/style/format/tests/test_main.py
+++ b/lookout/style/format/tests/test_main.py
@@ -9,6 +9,7 @@ import lookout.style.format.cmdline_tools as main
 class MainTests(unittest.TestCase):
     def test_handlers(self):
         raw_imports = """
+        from lookout.style.format.benchmarks.compare_quality_reports import compare_quality_reports_entry
         from lookout.style.format.benchmarks.evaluate_smoke import evaluate_smoke_entry
         from lookout.style.format.benchmarks.generate_smoke import generate_smoke_entry
         from lookout.style.format.benchmarks.general_report import print_reports
@@ -29,6 +30,7 @@ class MainTests(unittest.TestCase):
             "eval-smoke-dataset": "evaluate_smoke_entry",
             "rule": "dump_rule_entry",
             "calc-expected-vnodes-number": "calc_expected_vnodes_number_entry",
+            "compare-quality": "compare_quality_reports_entry",
         }
         parser = main.create_parser()
         subcommands = set([x.dest for x in parser._subparsers._actions[2]._choices_actions])


### PR DESCRIPTION
I know that we are not supposed to add new features while refactoring but it is so annoying to compare reports by your eyes each time so I add this small tool for it. 

Now you can just run
```bash
make report-quality
make report-compare
```

and see the difference between numbers.

Here the example: https://github.com/src-d/style-analyzer/pull/590#issuecomment-461429161