### PR TITLE
Fix Code Generation trailing symbols loss

### DIFF
--- a/lookout/style/format/classes.py
+++ b/lookout/style/format/classes.py
@@ -18,6 +18,7 @@ CLASS_INDEX = {cls: i for i, cls in enumerate(CLASSES)}
 EMPTY_CLS = frozenset([CLASS_INDEX[CLS_TAB_DEC], CLASS_INDEX[CLS_SPACE_DEC],
                        CLASS_INDEX[CLS_NOOP]])
 QUOTES_INDEX = {CLASS_INDEX[x] for x in [CLS_SINGLE_QUOTE, CLS_DOUBLE_QUOTE]}
+NEWLINE_INDEX = CLASS_INDEX[CLS_NEWLINE]
 CLS_TO_STR = {
     CLS_DOUBLE_QUOTE: '"',
     CLS_NEWLINE: "\n",  # FIXME(zurk) Not usable for \r\n endings

--- a/lookout/style/format/tests/bugs/004_generate_each_line/test.py
+++ b/lookout/style/format/tests/bugs/004_generate_each_line/test.py
@@ -1,3 +1,4 @@
+from itertools import repeat
 from pathlib import Path
 import sys
 import unittest
@@ -5,6 +6,7 @@ import unittest
 import bblfsh
 
 from lookout.style.format.analyzer import FormatAnalyzer
+from lookout.style.format.code_generator import CodeGenerator
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.tests.test_analyzer import FakeFile, get_train_config
 
@@ -37,6 +39,23 @@ class FeaturesTests(unittest.TestCase):
                 print("    Restored: ", repr(line), file=sys.stderr)
                 ok = False
         self.assertTrue(ok, "Original and restored files are different")
+
+    def test_vnode_positions(self):
+        code_generator = CodeGenerator(feature_extractor=self.extractor)
+        lines = self.code.decode("utf-8", "replace").splitlines()
+        lines.append("\r\n")
+        ok = True
+        for line_number, line in FormatAnalyzer._group_line_nodes(
+                self.y, self.y - 1, self.vnodes_y, self.vnodes, repeat(0)):
+            line_ys, line_ys_pred, line_vnodes_y, new_line_vnodes, line_winners = line
+            new_code_line = code_generator.generate_new_line(new_line_vnodes)
+            if lines[line_number - 1] != new_code_line:
+                print("Lines %d are different" % line_number, file=sys.stderr)
+                print(repr(lines[line_number - 1]), file=sys.stderr)
+                print(repr(new_code_line), file=sys.stderr)
+                print()
+                ok = False
+        self.assertTrue(ok, "Original and restored lines are different")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on PR https://github.com/src-d/style-analyzer/pull/604.

There is the last fix for `CodeGenerator` class during this refactoring stage.
I add add new test on [JS file](https://github.com/src-d/style-analyzer/compare/master...zurk:feature/code_generator_3?expand=1&title=Fix%20accumulated%20indentation%20position&body=Add%20hard%20test%20for%20CodeGenerator%0ASigned-off-by%3A%20Konstantin%20Slavnov%20%3Ckonstantin%40sourced.tech%3E#diff-331f6bd75aae1e00a76e57ac33676f0e) with terrible style: mixed tabs and spaces, trailing whitespaces.

I find out that CodeGenetaror often cannot come up with a proper line ending. 
For example, if you have a line 
```javascript
var t=0; /*
          * bla
          */
```
The suggested line will be 
```javascript
var t=0;
```
because `/*` relates to vnode from the next line. 
The same for trailing spaces of tabs. We just lose them.

All these problems are caused by multiline VirtualNodes that can steal the end of the predicted line. 
But we can not just restrict them because we return back to the ill-posed problem. So I try to split such nodes with a surgeon's touch:
1. We can be free to split lines with `y=None` just before we generate code. It does not affect the training pipeline at all. It is a new `FormatAnalyzer._split_vnodes_by_lines()`
2. We can split trailing spaces of tabs from next newline sequence. It does not affect our quality a lot because It makes difference only for files with trailing symbols.

Anyway, I run a quality report to see if there is an important difference and check that there are no fails. 

PS: Check out how new [`generate_new_line()`](https://github.com/src-d/style-analyzer/pull/602/files#diff-ca4d001b8b9bff239efdf01d64100535R91) looks like. It is So much better now! 