### PR TITLE
Move quality report entry point to lookout.style.format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ report-noisy: $(NOISY_REPORT_DIR)
 	python3 -m lookout.style.format quality-report-noisy --retrain -o $(NOISY_REPORT_DIR) \
 		2>&1 | tee $(NOISY_REPORT_DIR)/logs.txt
 report-quality: $(QUALITY_REPORT_DIR)
-	python3 -m lookout.style.format.benchmarks.top_repos_quality -o $(QUALITY_REPORT_DIR) \
+	python3 -m lookout.style.format quality-report -o $(QUALITY_REPORT_DIR) \
 		-i $(QUALITY_REPORT_REPOS_WITH_VNODE) 2>&1 | tee $(QUALITY_REPORT_DIR)/logs.txt
 report-compare:
 	python3 -m lookout.style.format compare-quality \

--- a/lookout/style/format/benchmarks/compare_quality_reports.py
+++ b/lookout/style/format/benchmarks/compare_quality_reports.py
@@ -4,7 +4,7 @@ from typing import TextIO, Union
 import pandas
 from tabulate import tabulate
 
-from lookout.style.format.benchmarks.top_repos_quality import FLOAT_PRECISION
+from lookout.style.format.benchmarks.quality_report import FLOAT_PRECISION
 
 
 _column_formats = {

--- a/lookout/style/format/benchmarks/expected_vnodes_number.py
+++ b/lookout/style/format/benchmarks/expected_vnodes_number.py
@@ -13,7 +13,7 @@ from lookout.core.test_helpers import server
 from tqdm import tqdm
 
 from lookout.style.format.analyzer import FormatAnalyzer
-from lookout.style.format.benchmarks.top_repos_quality import AnalyzerContextManager, \
+from lookout.style.format.benchmarks.quality_report import AnalyzerContextManager, \
     ensure_repo, handle_input_arg
 from lookout.style.format.feature_extractor import FeatureExtractor
 

--- a/lookout/style/format/benchmarks/general_report.py
+++ b/lookout/style/format/benchmarks/general_report.py
@@ -11,7 +11,6 @@ from typing import Any, Iterable, List, Mapping, NamedTuple, Optional, Sequence,
 
 from bblfsh import BblfshClient
 import jinja2
-from lookout.core import slogging
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2 import Change, File
@@ -153,9 +152,8 @@ def analyze_files(analyzer_type: Type[FormatAnalyzer], config: dict, model_path:
 
 @profile
 def print_reports(input_pattern: str, bblfsh: str, language: str, model_path: str,
-                  config: Union[str, dict] = "{}", log_level: str = "INFO") -> None:
+                  config: Union[str, dict] = "{}") -> None:
     """Print reports for a given model on a given dataset."""
-    slogging.setup(log_level, False)
     log = logging.getLogger("quality_report")
     config = config if isinstance(config, dict) else json.loads(config)
     for report in analyze_files(

--- a/lookout/style/format/cmdline_tools.py
+++ b/lookout/style/format/cmdline_tools.py
@@ -83,6 +83,7 @@ def create_parser() -> ArgumentParser:
         compare_quality_reports_entry
     from lookout.style.format.benchmarks.evaluate_smoke import evaluate_smoke_entry
     from lookout.style.format.benchmarks.generate_smoke import generate_smoke_entry
+    from lookout.style.format.benchmarks.quality_report import generate_quality_report
     from lookout.style.format.benchmarks.general_report import print_reports
     from lookout.style.format.benchmarks.quality_report_noisy import quality_report_noisy
     from lookout.style.format.benchmarks.expected_vnodes_number import \
@@ -108,6 +109,32 @@ def create_parser() -> ArgumentParser:
     eval_parser.add_argument("-n", "--n-files", default=0, type=int,
                              help="How many files with most mispredictions to show. "
                                   "If n <= 0 show all.")
+
+    # Generate quality report for the given data
+    quality_report_parser = add_parser("quality-report",
+                                       "Generate quality report on a given data.")
+    quality_report_parser.set_defaults(handler=generate_quality_report)
+    quality_report_parser.add_argument(
+        "-i", "--input", required=True,
+        help="csv file with repositories to make report. Should contain url, to and from columns.")
+    quality_report_parser.add_argument(
+        "-o", "--output", required=True,
+        help="Directory where to save results.")
+    quality_report_parser.add_argument(
+        "-f", "--force", default=False, action="store_true",
+        help="Force to overwrite results stored in output directory if True. \
+                 Stored results will be used if False.")
+    quality_report_parser.add_argument(
+        "-b", "--bblfsh", help="Bblfsh address to use.")
+    quality_report_parser.add_argument(
+        "--train-config", type=json.loads, default="{}",
+        help="Config for analyzer train in json format.")
+    quality_report_parser.add_argument(
+        "--database", default=None, help="sqlite3 database path to store the models."
+                                         "Temporary file is used if not set.")
+    quality_report_parser.add_argument(
+        "--fs", default=None, help="Model repository file system root. "
+                                   "Temporary directory is used if not set.")
 
     # Generate the quality report based on the artificial noisy dataset
     quality_report_noisy_parser = add_parser("quality-report-noisy", "Quality report on the "
@@ -211,8 +238,6 @@ def create_parser() -> ArgumentParser:
         "-o", "--output", required=True, help="Path to a output csv file.")
     calc_expected_vnodes.add_argument(
         "-r", "--runs", default=3, help="Number of repeats to ensure the result correctness.")
-    calc_expected_vnodes.add_argument(
-        "--log-level", default="DEBUG", help="Logging level")
 
     return parser
 

--- a/lookout/style/format/tests/test_main.py
+++ b/lookout/style/format/tests/test_main.py
@@ -16,6 +16,7 @@ class MainTests(unittest.TestCase):
         from lookout.style.format.benchmarks.quality_report_noisy import quality_report_noisy
         from lookout.style.format.cmdline_tools import dump_rule_entry
         from lookout.style.format.benchmarks.expected_vnodes_number import calc_expected_vnodes_number_entry
+        from lookout.style.format.benchmarks.quality_report import generate_quality_report
         """  # noqa E501
         imports = {}
         for line in raw_imports.splitlines():
@@ -25,6 +26,7 @@ class MainTests(unittest.TestCase):
                 imports[parts[-1]] = parts[1]
         action2handler = {
             "eval": "print_reports",
+            "quality-report": "generate_quality_report",
             "quality-report-noisy": "quality_report_noisy",
             "gen-smoke-dataset": "generate_smoke_entry",
             "eval-smoke-dataset": "evaluate_smoke_entry",

--- a/lookout/style/format/tests/test_quality_report.py
+++ b/lookout/style/format/tests/test_quality_report.py
@@ -12,7 +12,7 @@ from lookout.core.test_helpers import server
 from numpy.testing import assert_almost_equal
 
 from lookout.style.format.benchmarks.general_report import print_reports, QualityReportAnalyzer
-from lookout.style.format.benchmarks.top_repos_quality import _get_json_data, _get_metrics, \
+from lookout.style.format.benchmarks.quality_report import _get_json_data, _get_metrics, \
     _get_model_summary
 from lookout.style.format.tests import long_test
 from lookout.style.format.tests.test_analyzer import get_analyze_config, get_train_config


### PR DESCRIPTION
Closes https://github.com/src-d/style-analyzer/issues/435

Originally I was going to delete second entry point `print_reports()` but many tests use it so I decided to keep the function. It is not so important as `generate_quality_report` but can help in detailed analysis. 

I also rename `top_repos_quality.py` to `quality_report.py` because `top_repos_quality` is a confusing name and going to move code inside `benchmarks` module a little bit to make it well organized. 