### PR TITLE
Add filter_splits preprocesing function

### DIFF
--- a/lookout/style/typos/preprocessing.py
+++ b/lookout/style/typos/preprocessing.py
@@ -1,4 +1,4 @@
-from typing import Set, Union
+from typing import Set
 
 import pandas
 
@@ -19,14 +19,12 @@ def check_split(text: str, tokens: Set[str]) -> bool:
     return True
 
 
-def filter_splits(data: Union[pandas.DataFrame, str], tokens: Set[str]) -> pandas.DataFrame:
+def filter_splits(data: pandas.DataFrame, tokens: Set[str]) -> pandas.DataFrame:
     """
     Leave rows in a dataframe whose splits' tokens all belong to some vocabulary.
 
-    :param data: Dataframe or its .csv dump, containing column Columns.Split.
+    :param data: Dataframe which contains column Columns.Split.
     :param tokens: Set of tokens (reference vocabulary).
     :return: Filtered dataframe.
     """
-    if isinstance(data, str):
-        data = pandas.read_csv(data, index_col=0)
-    return data.loc[data[Columns.Split].apply(lambda x: check_split(x, tokens))]
+    return data[data[Columns.Split].apply(lambda x: check_split(x, tokens))]

--- a/lookout/style/typos/preprocessing.py
+++ b/lookout/style/typos/preprocessing.py
@@ -5,31 +5,28 @@ import pandas
 from lookout.style.typos.utils import Columns
 
 
-def check_split(split: str, tokens_set: Set[str]) -> bool:
+def check_split(text: str, tokens: Set[str]) -> bool:
     """
-    Check whether all elements of the split are in tokens_set.
+    Check whether all tokens of the text belong to the given set.
 
-    :param split: String of space-separated tokens.
-    :param tokens_set: Set of tokens (reference vocabulary).
-    :return: True when all tokens of split belong to tokens_set.
+    :param text: String of space-separated tokens.
+    :param tokens: Set of tokens (reference vocabulary).
+    :return: True when all tokens of the `text` belong to `tokens`.
     """
-    if type(split) != str:
-        return False
-
-    for token in split.split():
-        if token not in tokens_set:
+    for token in text.split():
+        if token not in tokens:
             return False
     return True
 
 
-def filter_splits(data: Union[pandas.DataFrame, str], tokens_set: Set[str]) -> pandas.DataFrame:
+def filter_splits(data: Union[pandas.DataFrame, str], tokens: Set[str]) -> pandas.DataFrame:
     """
     Leave rows in a dataframe whose splits' tokens all belong to some vocabulary.
 
     :param data: Dataframe or its .csv dump, containing column Columns.Split.
-    :param tokens_set: Set of tokens (reference vocabulary).
+    :param tokens: Set of tokens (reference vocabulary).
     :return: Filtered dataframe.
     """
-    token_split = list(data[Columns.Split])
-    filter_array = list(map(lambda x: check_split(x, tokens_set), token_split))
-    return data[filter_array]
+    if isinstance(data, str):
+        data = pandas.read_csv(data, index_col=0)
+    return data.loc[data[Columns.Split].apply(lambda x: check_split(x, tokens))]

--- a/lookout/style/typos/preprocessing.py
+++ b/lookout/style/typos/preprocessing.py
@@ -1,0 +1,35 @@
+from typing import Set, Union
+
+import pandas
+
+from lookout.style.typos.utils import Columns
+
+
+def check_split(split: str, tokens_set: Set[str]) -> bool:
+    """
+    Check whether all elements of the split are in tokens_set.
+
+    :param split: String of space-separated tokens.
+    :param tokens_set: Set of tokens (reference vocabulary).
+    :return: True when all tokens of split belong to tokens_set.
+    """
+    if type(split) != str:
+        return False
+
+    for token in split.split():
+        if token not in tokens_set:
+            return False
+    return True
+
+
+def filter_splits(data: Union[pandas.DataFrame, str], tokens_set: Set[str]) -> pandas.DataFrame:
+    """
+    Leave rows in a dataframe whose splits' tokens all belong to some vocabulary.
+
+    :param data: Dataframe or its .csv dump, containing column Columns.Split.
+    :param tokens_set: Set of tokens (reference vocabulary).
+    :return: Filtered dataframe.
+    """
+    token_split = list(data[Columns.Split])
+    filter_array = list(map(lambda x: check_split(x, tokens_set), token_split))
+    return data[filter_array]

--- a/lookout/style/typos/tests/test_preprocessing.py
+++ b/lookout/style/typos/tests/test_preprocessing.py
@@ -1,0 +1,31 @@
+import unittest
+
+import pandas
+from pandas.util.testing import assert_frame_equal
+
+from lookout.style.typos.preprocessing import check_split, filter_splits
+from lookout.style.typos.utils import Columns
+
+
+class PreprocessingTest(unittest.TestCase):
+    def test_check_split(self):
+        self.assertTrue(check_split("get the value", {"get", "the", "value", "here"}))
+        self.assertFalse(check_split("get the value", {"get", "value", "here"}))
+
+    def test_filter_splits(self):
+        data = pandas.DataFrame([["get value", "get"],
+                                 ["get value", "value"],
+                                 ["gut", "gut"],
+                                 ["put tok", "put"],
+                                 ["put tok", "tok"],
+                                 ["put", "put"]], columns=[Columns.Split, Columns.Token])
+        vocabulary = {"get", "value", "put"}
+        result = pandas.DataFrame([["get value", "get"],
+                                   ["get value", "value"],
+                                   ["put", "put"]], columns=[Columns.Split, Columns.Token],
+                                  index=[0, 1, 5])
+        assert_frame_equal(filter_splits(data, vocabulary), result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Continue with functions for preprocessing raw data.

This one filters identifiers by leaving only those, whose tokens are all in the vocabulary. This filtered data is then used for creating train and test datasets with artificially made typos.