### PR TITLE
Remove flatten_data function from typos utils

### DIFF
--- a/lookout/style/typos/analyzer.py
+++ b/lookout/style/typos/analyzer.py
@@ -13,7 +13,7 @@ import pandas
 from sourced.ml.algorithms import TokenParser, uast2sequence
 
 from lookout.style.typos.corrector_manager import TyposCorrectorManager
-from lookout.style.typos.utils import Columns, flatten_data
+from lookout.style.typos.utils import Columns, flatten_df_by_column
 
 
 class IdTyposAnalyzer(Analyzer):
@@ -136,7 +136,7 @@ class IdTyposAnalyzer(Analyzer):
         df = pandas.DataFrame(columns=[self.INDEX_COLUMN, Columns.Split])
         df[self.INDEX_COLUMN] = range(len(identifiers))
         df[Columns.Split] = [" ".join(self.parser.split(i)) for i in identifiers]
-        df = flatten_data(df, new_column_name=Columns.Token)
+        df = flatten_df_by_column(df, Columns.Split, Columns.Token, str.split)
         suggestions = self.model.suggest(df, n_candidates=self.n_candidates, return_all=False)
         suggestions = self.filter_suggestions(df, suggestions)
         grouped_suggestions = defaultdict(dict)

--- a/lookout/style/typos/tests/test_corrector_utils.py
+++ b/lookout/style/typos/tests/test_corrector_utils.py
@@ -8,7 +8,7 @@ import pandas
 from pandas.util.testing import assert_frame_equal
 
 from lookout.style.typos.utils import (
-    add_context_info, Columns, flatten_data, flatten_df_by_column,
+    add_context_info, Columns, flatten_df_by_column,
     rank_candidates, read_frequencies, read_vocabulary, suggestions_to_df, suggestions_to_flat_df)
 
 
@@ -40,7 +40,8 @@ class DataTransformationsTest(unittest.TestCase):
     def test_flatten_data(self):
         raw_data = pandas.read_csv(join(TEST_DATA_PATH, "raw_test_data.csv.xz"),
                                    index_col=0).infer_objects()
-        assert_frame_equal(flatten_data(raw_data, Columns.Token), self.flat_data)
+        assert_frame_equal(flatten_df_by_column(raw_data, Columns.Split, Columns.Token, str.split),
+                           self.flat_data)
         assert_frame_equal(flatten_df_by_column(self.custom_data, Columns.Split, Columns.Token,
                                                 str.split), self.flat_custom_data)
 

--- a/lookout/style/typos/utils.py
+++ b/lookout/style/typos/utils.py
@@ -48,7 +48,7 @@ def flatten_df_by_column(data: pandas.DataFrame, column: str, new_column: str,
                          apply_function=lambda x: x) -> pandas.DataFrame:
     """
     Flatten DataFrame by `column` with extracted elements put to `new_column`. \
-    Operation happens out-of-place.
+    Operation runs out-of-place.
 
     :param data: DataFrame to flatten.
     :param column: Column to expand.
@@ -64,21 +64,6 @@ def flatten_df_by_column(data: pandas.DataFrame, column: str, new_column: str,
     result = pandas.DataFrame(flat_values, columns=data.columns)
     result[new_column] = flat_column
     return result.infer_objects()
-
-
-def flatten_data(data: pandas.DataFrame, new_column_name=Columns.Token) -> pandas.DataFrame:
-    """
-    Flatten identifiers data in column `new_column_name`. Operation happels out-of-place.
-
-    :param data: DataFrame containing column `new_column_name` with splitted identifiers \
-                 either as strings or as lists of tokens.
-    :param new_column_name: Name of column to put tokens from splits to.
-    :return: Flattened DataFrame.
-    """
-    apply_function = (lambda x: x) if isinstance(data[Columns.Split].tolist()[0], list) \
-        else (lambda x: str(x).split())
-    return flatten_df_by_column(data, Columns.Split, new_column_name,
-                                apply_function=apply_function)
 
 
 def add_context_info(data: pandas.DataFrame) -> pandas.DataFrame:


### PR DESCRIPTION
This function can be replaced by one call to another function, I don't think it should be kept.