### PR TITLE
Remove prepare_files and use parse_files from lookout-sdk-ml instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM srcd/lookout-sdk-ml:0.13.1
+FROM srcd/lookout-sdk-ml:0.14.0
 
 COPY requirements.txt style-analyzer/requirements.txt
 

--- a/lookout/style/format/benchmarks/general_report.py
+++ b/lookout/style/format/benchmarks/general_report.py
@@ -12,6 +12,7 @@ from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2 import Change, File
 from lookout.core.data_requests import DataService, request_files
+from lookout.core.lib import parse_files
 import numpy
 from sklearn.exceptions import NotFittedError
 
@@ -22,7 +23,7 @@ from lookout.style.format.benchmarks.time_profile import profile
 from lookout.style.format.descriptions import describe_rule
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.model import FormatModel
-from lookout.style.format.utils import generate_comment, get_classification_report, prepare_files
+from lookout.style.format.utils import generate_comment, get_classification_report
 from lookout.style.format.virtual_node import VirtualNode
 
 
@@ -127,7 +128,10 @@ def analyze_files(analyzer_type: Type[FormatAnalyzer], config: dict, model_path:
         raise NotFittedError()
     rules = model[language]
     client = BblfshClient(bblfsh)
-    files = prepare_files(glob.glob(input_pattern, recursive=True), client, language)
+    files = parse_files(filepaths=glob.glob(input_pattern, recursive=True),
+                        line_length_limit=rules.origin_config["line_length_limit"],
+                        overall_size_limit=rules.origin_config["overall_size_limit"],
+                        client=client, language=language, log=log)
     log.info("Model parameters: %s" % rules.origin_config)
     log.info("Rules stats: %s" % rules)
     log.info("Number of files: %s" % (len(files)))

--- a/lookout/style/format/benchmarks/quality_report_noisy.py
+++ b/lookout/style/format/benchmarks/quality_report_noisy.py
@@ -19,6 +19,7 @@ from yaml import safe_load
 
 from lookout.style.format.analyzer import FormatAnalyzer
 from lookout.style.format.benchmarks.general_report import FakeDataService
+from lookout.style.format.config import DEFAULT_CONFIG
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.model import FormatModel
 from lookout.style.format.rules import Rules
@@ -54,16 +55,17 @@ def train(training_dir: str, ref: ReferencePointer, output_path: str, language: 
         with open(config) as fh:
             config = safe_load(fh)
     else:
-        config = FormatAnalyzer.defaults_for_train
+        config = DEFAULT_CONFIG
     filepaths = glob.glob(os.path.join(training_dir, "**", "*.js"), recursive=True)
     model = FormatAnalyzer.train(ref, config, FakeDataService(
         bblfsh_client=bblfsh_client,
-        files=parse_files(filepaths=filepaths,
-                          line_length_limit=config["global"]["line_length_limit"],
-                          overall_size_limit=config["global"]["overall_size_limit"],
-                          client=bblfsh_client,
-                          language=language,
-                          log=log),
+        files=parse_files(
+            filepaths=filepaths,
+            line_length_limit=config["train"]["language_defaults"]["line_length_limit"],
+            overall_size_limit=config["train"]["language_defaults"]["overall_size_limit"],
+            client=bblfsh_client,
+            language=language,
+            log=log),
         changes=None))
     model.save(output_path)
     return model

--- a/lookout/style/format/tests/bugs/001_analyze_skips_lines/test.py
+++ b/lookout/style/format/tests/bugs/001_analyze_skips_lines/test.py
@@ -8,10 +8,10 @@ from lookout.core import slogging
 from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.data_requests import DataService
+from lookout.core.lib import parse_files
 
 from lookout.style.format.analyzer import FileFix, LineFix  # noqa: F401
 from lookout.style.format.benchmarks.general_report import analyze_files, FormatAnalyzerSpy
-from lookout.style.format.utils import prepare_files
 
 
 class AnalyzeSkipsLines(unittest.TestCase):
@@ -23,8 +23,12 @@ class AnalyzeSkipsLines(unittest.TestCase):
         fixes = []  # type: FileFix
         bblfsh_client = BblfshClient(self.bblfsh_endpoint)
         basedir = os.path.dirname(__file__)
-        base_files = list(prepare_files(
-            [os.path.join(basedir, "find_chrome_base.js")], bblfsh_client, "javascript"))
+        base_files = parse_files(
+            filepaths=[os.path.join(basedir, "find_chrome_base.js")],
+            line_length_limit=500,
+            overall_size_limit=5 << 20,
+            client=bblfsh_client,
+            language="javascript")
         base_files[0].path = os.path.join(basedir, "find_chrome_head.js")
 
         class Runner(FormatAnalyzerSpy):

--- a/lookout/style/format/utils.py
+++ b/lookout/style/format/utils.py
@@ -2,15 +2,11 @@
 from typing import Any, Dict, Iterable, Sequence
 import warnings
 
-from bblfsh import BblfshClient
-from bblfsh.client import NonUTF8ContentException
 from lookout.core.api.service_analyzer_pb2 import Comment
 from lookout.core.api.service_data_pb2 import File
-from lookout.core.lib import filter_files_by_path
 import numpy
 from sklearn.exceptions import UndefinedMetricWarning
 import sklearn.metrics
-from tqdm import tqdm
 
 
 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
@@ -35,46 +31,6 @@ class FakeDataStub:
         :return: sequence of files.
         """
         return self.files
-
-
-def prepare_files(filenames: Iterable[str], client: BblfshClient,
-                  language: str) -> Iterable[File]:
-    """
-    Prepare the given folder for analysis by extracting UASTs and creating the gRPC wrappers.
-
-    :param filenames: List of paths to files to analyze.
-    :param client: Babelfish client. Babelfish server should be started accordingly.
-    :param language: Language to consider. Will discard the other languages.
-    :return: Iterator of File-s with content, uast, path and language set.
-    """
-    files = []
-    for file in tqdm(filter_files_by_path(list(filenames))):
-        try:
-            res = client.parse(file)
-        except NonUTF8ContentException:
-            # skip files that can't be parsed because of UTF-8 decoding errors.
-            continue
-        if res.status == 0 and res.language.lower() == language.lower():
-            uast = res.uast
-            path = file
-            with open(file) as f:
-                content = f.read().encode("utf-8")
-            files.append(File(content=content, uast=uast, path=path,
-                              language=res.language.lower()))
-    return files
-
-
-def prepare_data_stub(input_pattern: str, client: BblfshClient, language: str):
-    """
-    Prepare the given folder for analysis and mimic DataStub from core.
-
-    :param input_pattern: Path to folder with source code -  should be in a format compatible with
-                          glob (ends with **/*  and surrounded by quotes. Ex: `path/**/*`).
-    :param client: Babelfish client. Babelfish server should be started accordingly.
-    :param language: Language to consider. Will discard the other languages.
-    :return: Iterator of File-s with content, uast, path and language set.
-    """
-    return FakeDataStub(files=prepare_files(input_pattern, client, language))
 
 
 def generate_comment(filename: str, confidence: int, line: int, text: str) -> Comment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sourced-ml==0.8.2
-lookout-sdk-ml==0.13.1
+lookout-sdk-ml==0.14.0
 scikit-learn==0.20.1
 scikit-optimize==0.5.2
 pandas==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     keywords=["machine learning on source code", "babelfish", "lookout"],
     install_requires=[
         "sourced-ml>=0.8.2,<0.9",
-        "lookout-sdk-ml>=0.13.1,<0.14",
+        "lookout-sdk-ml>=0.14.0,<0.15",
         "scikit-learn>=0.20,<2.0",
         "scikit-optimize>=0.5,<2.0",
         "pandas>=0.22,<2.0",


### PR DESCRIPTION
Signed-off-by: Waren Long <waren@sourced.tech>

Fix https://github.com/src-d/style-analyzer/issues/502 and https://github.com/src-d/style-analyzer/issues/501 again

This PR needs https://github.com/src-d/lookout-sdk-ml/pull/64 to be merged first as well as the latest lookout-sdk-ml release