### PR TITLE
Add fasttext training function with tests

### DIFF
--- a/lookout/style/typos/datasets_preparation.py
+++ b/lookout/style/typos/datasets_preparation.py
@@ -161,7 +161,8 @@ def train_fasttext(data: pandas.DataFrame, params: Optional[Mapping[str, Any]] =
                    size: Number of identifiers to pick from the given data to train fasttext on.
                    corrupt: Value indicating whether to make random artificial typos in \
                             the training data. Identifiers are corrupted with `typo_probability`.
-                   typo_probability: Probability with which a token is corrupted, used if `corrupt=True`.
+                   typo_probability: Probability with which a token is corrupted, used \
+                                     if `corrupt=True`.
                    add_typo_probability: Probability with which another corruption happens in a \
                                   corrupted token, used if `corrupt=True`.
                    fasttext_path: Path where to store the trained fasttext model.

--- a/lookout/style/typos/tests/test_datasets_preparation.py
+++ b/lookout/style/typos/tests/test_datasets_preparation.py
@@ -7,7 +7,7 @@ import unittest
 from gensim.models import FastText
 import pandas
 
-from lookout.style.typos.datasets_preparation import get_datasets, prepare_data, tune_fasttext_model
+from lookout.style.typos.datasets_preparation import get_datasets, prepare_data, train_fasttext
 from lookout.style.typos.utils import Columns, read_frequencies, read_vocabulary
 
 
@@ -74,7 +74,7 @@ class FasttextTest(unittest.TestCase):
                                index_col=0)
         temp_dir = tempfile.mkdtemp()
         params = {"size": 1000, "fasttext_path": os.path.join(temp_dir, "ft.bin"), "dim": 5}
-        tune_fasttext_model(data, params)
+        train_fasttext(data, params)
         model = FastText.load_fasttext_format(params["fasttext_path"])
         self.assertTupleEqual(model.wv["get"].shape, (5,))
         shutil.rmtree(temp_dir)

--- a/lookout/style/typos/tests/test_datasets_preparation.py
+++ b/lookout/style/typos/tests/test_datasets_preparation.py
@@ -72,11 +72,12 @@ class FasttextTest(unittest.TestCase):
     def test_get_fasttext_model(self):
         data = pandas.read_csv(str(pathlib.Path(__file__).parent / "prepared_data.csv.xz"),
                                index_col=0)
-        with tempfile.NamedTemporaryFile() as ft_file:
-            params = {"size": 1000, "fasttext_path": ft_file.name, "dim": 5}
-            tune_fasttext_model(data, params)
-            model = FastText.load_fasttext_format(ft_file.name)
-            self.assertTupleEqual(model.wv["get"].shape, (5,))
+        temp_dir = tempfile.mkdtemp()
+        params = {"size": 1000, "fasttext_path": os.path.join(temp_dir, "ft.bin"), "dim": 5}
+        tune_fasttext_model(data, params)
+        model = FastText.load_fasttext_format(params["fasttext_path"])
+        self.assertTupleEqual(model.wv["get"].shape, (5,))
+        shutil.rmtree(temp_dir)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ xgboost==0.72.1
 tabulate==0.8.2
 python-igraph==0.7.1.post6
 srcd_smart_open==1.9.0
+git+https://github.com/facebookresearch/fastText

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "tabulate>=0.8.0,<2.0",
         "python-igraph>=0.7.0,<2.0",
         "srcd_smart_open==1.9.0",
+        "fastText @ git+https://github.com/facebookresearch/fastText",
     ],
     extras_require={
         "tf": tf_requires,


### PR DESCRIPTION
Train fasttext from scratch on the given data.

1. **Artificial typos are added to the input data** (the model expects data with aready correct identifiers (or major part is correct)).
Training on raw dataset of identifiers is not enough - this way model puts all misspelled words close to each other, but far from their corrections or even misspellings of the same words. But when we take several examples of the same identifier as it is and with different typos in it, the model starts putting all misspellings of one word in a single cluster, which is close to the embedding of that correct word.
**Tl;dr** it's the best way I've tried so far and it's easy.

2. I use (**original implementation of FastText**)[https://github.com/facebookresearch/fastText/tree/master/python], because in comparison with `gensim` it works much better.
I don't know why. I've tried running them on exactly the same data with exactly the same parameters, and `gensim` gives much worse results (it doesn't cluster misspellings of the same word together and close to that word). I really don't like it, because `gensim` seems more stable, and this way we need to add 2 dependencies for using embeddings, but for now I think it's the best we can do - embeddings are important for the model, good embeddings significantly improve the quality of corrections.