### PR TITLE
Refactor corruption and datasets preparation

### DIFF
--- a/lookout/style/typos/corruption.py
+++ b/lookout/style/typos/corruption.py
@@ -5,6 +5,7 @@ import random
 import string
 from typing import NamedTuple, Tuple
 
+import numpy
 import pandas
 from tqdm import tqdm
 
@@ -64,19 +65,17 @@ def rand_swap(token: str) -> str:
     return token[:pos] + token[pos + 1] + token[pos] + token[pos + 2:]
 
 
-def _rand_typo(token_split: Tuple[str, str], typo_probability: float,
-               add_typo_probability: float) -> Tuple[str, str]:
-    token, split = token_split
+def _rand_typo(token_split: Tuple[str, str, bool], add_typo_probability: float) -> Tuple[str, str]:
+    token, split, corrupt = token_split
     typoed_token = token
-    if len(token) > 1 and random.uniform(0, 1) < typo_probability:
+    if len(token) > 1 and corrupt:
         typoed_token = ""
-        while len(typoed_token) < 2:
+        while len(typoed_token) < 2 or typoed_token == token:
             typoed_token = random.choice([rand_insert, rand_delete, rand_substitution,
                                           rand_swap])(token)
             while random.uniform(0, 1) < add_typo_probability:
                 typoed_token = random.choice([rand_insert, rand_delete, rand_substitution,
                                               rand_swap])(typoed_token)
-    if typoed_token != token:
         split = split.replace(token, typoed_token)
     return typoed_token, split
 
@@ -101,24 +100,23 @@ def corrupt_tokens_in_df(data: pandas.DataFrame, typo_probability: float,
              which contain tokens and corresponding splits from the `data`. Columns.Token and \
              Columns.Split now contain partially corrupted tokens and corresponding splits.
     """
-    tokens_splits = list(zip(data[Columns.Token].astype(str), data[Columns.Split].astype(str)))
+    corrupt = numpy.zeros(len(data))
+    corrupt[numpy.random.choice(len(data), int(typo_probability * len(data)), replace=False)] = 1
+    tokens_splits = list(zip(data[Columns.Token].astype(str), data[Columns.Split].astype(str),
+                             corrupt.astype(bool)))
 
     def _wrap(x):
         if log_level == logging.DEBUG:
             return tqdm(x, total=len(tokens_splits))
         else:
             return x
-
     with Pool(threads_number) as pool:
         typoed_tokens_splits = list(_wrap(pool.imap(
-            partial(_rand_typo,
-                    typo_probability=typo_probability,
-                    add_typo_probability=add_typo_probability), tokens_splits,
+            partial(_rand_typo, add_typo_probability=add_typo_probability), tokens_splits,
             chunksize=min(8192, 1 + len(tokens_splits) // threads_number))))
-
     result = data.copy()
     result[Columns.Token] = [x[0] for x in typoed_tokens_splits]
     result[Columns.Split] = [x[1] for x in typoed_tokens_splits]
-    result[Columns.CorrectToken] = data[Columns.Token]
-    result[Columns.CorrectSplit] = data[Columns.Split]
+    result[Columns.CorrectToken] = data[Columns.Token].astype(str)
+    result[Columns.CorrectSplit] = data[Columns.Split].astype(str)
     return result

--- a/lookout/style/typos/tests/test_corruption.py
+++ b/lookout/style/typos/tests/test_corruption.py
@@ -19,7 +19,7 @@ class CorruptionTest(unittest.TestCase):
                 self.assertEqual(dist_calculator.compare(corrupted, 1), 1)
                 self.assertEqual(len(corrupted), len(token) + distance)
         for _ in range(10):
-            corrupted, _ = _rand_typo((token, token), 1.0, 0.0)
+            corrupted, _ = _rand_typo((token, token, 1), 0.0)
             self.assertEqual(dist_calculator.compare(corrupted, 1), 1)
 
     def test_corrupt_tokens_in_df(self):

--- a/lookout/style/typos/tests/test_preparation.py
+++ b/lookout/style/typos/tests/test_preparation.py
@@ -62,11 +62,11 @@ class DatasetsTest(unittest.TestCase):
         prepared = pandas.read_csv(str(TEST_DATA_DIR / "prepared_data.csv.xz"),
                                    index_col=0, keep_default_na=False)
         train, test = get_datasets(prepared, train_size=1000, test_size=100,
-                                   typo_probability=0.5, add_typo_probability=0.5)
+                                   typo_probability=0.5, add_typo_probability=0.05)
         self.assertTrue({Columns.Token, Columns.CorrectToken, Columns.Split,
                          Columns.CorrectSplit}.issubset(set(train.columns)))
         corrupted = sum(train[Columns.Token] != train[Columns.CorrectToken])
-        self.assertAlmostEqual(corrupted, 500, delta=50)
+        self.assertEqual(corrupted, 500)
         self.assertEqual(len(train), 1000)
         self.assertEqual(len(test), 100)
         print(len(set(train[Columns.Token]).intersection(set(test[Columns.Token]))))


### PR DESCRIPTION
1. Replace original indices with ranges in generated datasets.
2. Make the amount of corrupted tokens fixed during artificial typos generation.