### PR TITLE
Add expand_vocabulary method to the corrector

### DIFF
--- a/lookout/style/typos/corrector.py
+++ b/lookout/style/typos/corrector.py
@@ -1,6 +1,6 @@
 """Typo correction model."""
 from itertools import chain
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from modelforge import Model
 import pandas
@@ -97,6 +97,14 @@ class TyposCorrector(Model):
         """
         self.generator.construct(vocabulary_file, frequencies_file, embeddings_file,
                                  neighbors_number, edit_candidates, max_distance, radius)
+
+    def expand_vocabulary(self, additional_tokens: Set[str]) -> None:
+        """
+        Add given tokens to the model's vocabulary.
+
+        :param additional_tokens: Set of tokens to add to the vocabulary.
+        """
+        self.generator.expand_vocabulary(additional_tokens)
 
     def train(self, data: pandas.DataFrame, candidates:  Optional[str] = None,
               save_candidates_file: Optional[str] = None,

--- a/lookout/style/typos/generation.py
+++ b/lookout/style/typos/generation.py
@@ -347,7 +347,7 @@ class CandidatesGenerator(Model):
         for key, val in self.checker._words.items():
             wordvals[delstrs_map[key]] = val
         tree["checker"]["_words"] = wordvals
-        tree["tokens"] = merge_strings(list(self.tokens))
+        tree["tokens"] = merge_strings(sorted(self.tokens))
         vocab_strings = [""] * len(self.wv.vocab)
         vocab_counts = numpy.zeros(len(vocab_strings), dtype=numpy.uint32)
         for key, val in self.wv.vocab.items():

--- a/lookout/style/typos/tests/test_corrector.py
+++ b/lookout/style/typos/tests/test_corrector.py
@@ -52,6 +52,12 @@ class TyposCorrectorTest(unittest.TestCase):
         suggestions = self.corrector.suggest_on_file(join(TEST_DATA_PATH, "test_data.csv.xz"))
         self.assertSetEqual(set(suggestions.keys()), set(self.data.index))
 
+    def test_expand_vocabulary(self):
+        additional_tokens = {"a", "aaa", "123", "get", "341"}
+        vocabulary = self.corrector.generator.tokens
+        self.corrector.expand_vocabulary(additional_tokens)
+        self.assertSetEqual(self.corrector.generator.tokens, vocabulary.union(additional_tokens))
+
     @unittest.skip("CandidatesGenerator.__eq__ needs refactoring. Test is currently flaky.")
     def test_save_load(self):
         self.corrector.train(self.data)

--- a/lookout/style/typos/tests/test_generation.py
+++ b/lookout/style/typos/tests/test_generation.py
@@ -74,6 +74,15 @@ class GeneratorTest(unittest.TestCase):
             self.assertSetEqual(set(candidates[Columns.Token].values),
                                 set(test_data[Columns.Token].values))
 
+    def test_expand_vocabulary(self):
+        generator = CandidatesGenerator()
+        generator.construct(VOCABULARY_FILE, VOCABULARY_FILE, FASTTEXT_DUMP_FILE,
+                            neighbors=3, edit_candidates=3, max_distance=3, radius=3)
+        additional_tokens = {"a", "aaa", "123", "get", "341"}
+        vocabulary = generator.tokens
+        generator.expand_vocabulary(additional_tokens)
+        self.assertSetEqual(generator.tokens, vocabulary.union(additional_tokens))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Super small feature: expand the vocabulary in the corrector.

After adding new tokens to the vocabulary through this method, model:
- will be enabled to suggest those new tokens as corrections
- but still will probably suggest to correct them themselves (as being inside the vocabulary is not a green light for the check pass, for we don't have a perfect vocabulary and also there are typos that are correct words of the wrong meaning).

For now i believe that this *never-suggest-corrections-for-me* set must be held in analyzer (will be implementer in the upcoming PR). But we can also try different configurations in the future.