### PR TITLE
Always add token itself to the candidates

### DIFF
--- a/lookout/style/typos/analyzer.py
+++ b/lookout/style/typos/analyzer.py
@@ -259,10 +259,11 @@ class IdTyposAnalyzer(Analyzer):
         for index, candidates in suggestions.items():
             filtered_candidates = []
             for candidate in candidates:
-                if candidate[0] == tokens[index] or \
-                        candidate[1] < self.config["confidence_threshold"]:
+                if candidate[1] < self.config["confidence_threshold"]:
                     break
                 filtered_candidates.append(candidate)
+                if candidate[0] == tokens[index]:
+                    break
             if filtered_candidates:
                 filtered_suggestions[index] = filtered_candidates
         return filtered_suggestions

--- a/lookout/style/typos/generation.py
+++ b/lookout/style/typos/generation.py
@@ -210,8 +210,7 @@ class CandidatesGenerator(Model):
 
         candidate_tokens = {candidate for candidate in candidate_tokens
                             if candidate in self.tokens}
-        if not len(candidate_tokens):
-            candidate_tokens.add(typo_info.typo)
+        candidate_tokens.add(typo_info.typo)
         return candidate_tokens
 
     def _generate_features(self, typo_info: TypoInfo, dist: int, typo_vec: numpy.ndarray,
@@ -259,6 +258,7 @@ class CandidatesGenerator(Model):
                 self._min_cos(candidate_vec, context),
                 self._cos(typo_vec, candidate_vec),
                 dist,
+                int(candidate in self.tokens),
             ),
             before_vec,
             after_vec,

--- a/lookout/style/typos/tests/test_analyzer.py
+++ b/lookout/style/typos/tests/test_analyzer.py
@@ -138,7 +138,8 @@ class AnalyzerPayloadTest(unittest.TestCase):
                            2: [("token", 0.98),
                                ("taken", 0.3),
                                ("tokem", 0.01)]}
-        cls.filtered_suggestions = {1: [("get", 0.9)],
+        cls.filtered_suggestions = {1: [("get", 0.9),
+                                        ("gpt", 0.3)],
                                     2: [("token", 0.98),
                                         ("taken", 0.3)]}
 


### PR DESCRIPTION
Right now the token is always added to the candidates during generation, but still will not be returned as a candidate, if there are too much candidates with higher probabilities. 

~~The details should be discussed, so WIP for now.~~
UPD I guess good to merge, small almost nothing-affecting changes.