### PR TITLE
Add reporter for typos analyzer

### DIFF
--- a/lookout/style/cloner.py
+++ b/lookout/style/cloner.py
@@ -1,44 +1,52 @@
 """Cloning utilities for git repositories."""
 
-from itertools import repeat
 import logging
-import multiprocessing
 import os
 from typing import Dict, Optional, Sequence, Tuple
 
 from dulwich import porcelain
+from joblib import delayed, Parallel
+
+
+class ParallelWriteToLogs(Parallel):
+    """Parallel which logs progress using logger."""
+
+    _log = logging.getLogger("Parallel")
+
+    def _print(self, msg, msg_args):
+        """Display the message using `self._log.info`."""
+        if not self.verbose:
+            return
+        self._log.info(msg, *msg_args)
 
 
 class Cloner:
-    """
-    Class to clone a list of git repositories in parallel.
-    """
+    """Class to clone a list of git repositories in parallel."""
 
     _log = logging.getLogger("Cloner")
 
-    def __init__(self, location: str, processes: Optional[int] = None):
+    def __init__(self, location: str, n_jobs: Optional[int] = -1):
         """
-        Create new Cloner instance.
+        Initialize a new Cloner instance.
 
         :param location: Path to the dirrectory where repositories is saved.
-        :param processes: Number of processes to use. 'os.cpu_count()' is used by default.
+        :param n_jobs: Number of processes to use. 'os.cpu_count()' is used by default.
         """
         os.makedirs(location, exist_ok=True)
         self._location = location
-        self._processes = processes
+        self._processes = n_jobs
 
-    def clone_repositories(self, repositories: Sequence[str]) -> Dict[str, str]:
+    def clone(self, repositories: Sequence[str]) -> Dict[str, str]:
         """
         Run repositories cloning in parallel.
 
         :param repositories: List of URLs to clone.
-        :return: Mapping from provided URL to the location in the file system for successfully \
+        :return: Mapping from the provided URLs to the file system paths of the successfully \
                  downloaded repositories.
         """
         self._log.info("start cloning %d repositories", len(repositories))
-        with multiprocessing.Pool(self._processes) as pool:
-            repo_paths = pool.map(self._clone_repository,
-                                  zip(repositories, repeat(self._location)))
+        repo_paths = ParallelWriteToLogs(n_jobs=-1, verbose=10, backend="multiprocessing")(
+            delayed(self._clone_repository)(repo, self._location) for repo in repositories)
         repositories_dir = {repo: git_dir for repo, git_dir in repo_paths if git_dir}
         self._log.info("successfully cloned %d/%d repositories",
                        len(repositories_dir), len(repositories))
@@ -52,11 +60,10 @@ class Cloner:
         :param url: Repository URL to get name for.
         :return: Generated repository name.
         """
-        return "-".join(url.split("/")[-2:])
+        return "@".join(url.split("/")[-3:])
 
     @staticmethod
-    def _clone_repository(args: Tuple[str, str]) -> Tuple[str, Optional[str]]:
-        repository, repos_cache = args
+    def _clone_repository(repository: str, repos_cache: str) -> Tuple[str, Optional[str]]:
         if os.path.exists(repository):
             Cloner._log.info("%s exists", repository)
             return repository, repository
@@ -65,9 +72,10 @@ class Cloner:
             Cloner._log.info("%s was found at %s. Skipping", repository, git_dir)
             return repository, git_dir
         try:
-            porcelain.clone(repository, git_dir)
-            Cloner._log.info("%s was cloned to %s", repository, git_dir)
+            with open(os.devnull, "wb") as devnull:
+                porcelain.clone(repository, git_dir, bare=True, errstream=devnull)
+            Cloner._log.debug("%s was cloned to %s", repository, git_dir)
             return repository, git_dir
         except Exception:
-            Cloner._log.exception("Failed to clone %s to %s", repository, git_dir)
+            Cloner._log.exception("failed to clone %s to %s", repository, git_dir)
             return repository, None

--- a/lookout/style/cloner.py
+++ b/lookout/style/cloner.py
@@ -1,0 +1,73 @@
+"""Cloning utilities for git repositories."""
+
+from itertools import repeat
+import logging
+import multiprocessing
+import os
+from typing import Dict, Optional, Sequence, Tuple
+
+from dulwich import porcelain
+
+
+class Cloner:
+    """
+    Class to clone a list of git repositories in parallel.
+    """
+
+    _log = logging.getLogger("Cloner")
+
+    def __init__(self, location: str, processes: Optional[int] = None):
+        """
+        Create new Cloner instance.
+
+        :param location: Path to the dirrectory where repositories is saved.
+        :param processes: Number of processes to use. 'os.cpu_count()' is used by default.
+        """
+        os.makedirs(location, exist_ok=True)
+        self._location = location
+        self._processes = processes
+
+    def clone_repositories(self, repositories: Sequence[str]) -> Dict[str, str]:
+        """
+        Run repositories cloning in parallel.
+
+        :param repositories: List of URLs to clone.
+        :return: Mapping from provided URL to the location in the file system for successfully \
+                 downloaded repositories.
+        """
+        self._log.info("start cloning %d repositories", len(repositories))
+        with multiprocessing.Pool(self._processes) as pool:
+            repo_paths = pool.map(self._clone_repository,
+                                  zip(repositories, repeat(self._location)))
+        repositories_dir = {repo: git_dir for repo, git_dir in repo_paths if git_dir}
+        self._log.info("successfully cloned %d/%d repositories",
+                       len(repositories_dir), len(repositories))
+        return repositories_dir
+
+    @staticmethod
+    def get_repo_name(url: str) -> str:
+        """
+        Convert URL to repository name.
+
+        :param url: Repository URL to get name for.
+        :return: Generated repository name.
+        """
+        return "-".join(url.split("/")[-2:])
+
+    @staticmethod
+    def _clone_repository(args: Tuple[str, str]) -> Tuple[str, Optional[str]]:
+        repository, repos_cache = args
+        if os.path.exists(repository):
+            Cloner._log.info("%s exists", repository)
+            return repository, repository
+        git_dir = os.path.join(repos_cache, Cloner.get_repo_name(repository))
+        if os.path.exists(git_dir):
+            Cloner._log.info("%s was found at %s. Skipping", repository, git_dir)
+            return repository, git_dir
+        try:
+            porcelain.clone(repository, git_dir)
+            Cloner._log.info("%s was cloned to %s", repository, git_dir)
+            return repository, git_dir
+        except Exception:
+            Cloner._log.exception("Failed to clone %s to %s", repository, git_dir)
+            return repository, None

--- a/lookout/style/reporter.py
+++ b/lookout/style/reporter.py
@@ -1,0 +1,146 @@
+"""General utilities to generate performance reports for analyzers."""
+
+import logging
+import os
+import shutil
+import tempfile
+from typing import Any, Dict, Iterable, Iterator, NamedTuple, Optional, Sequence, Tuple
+
+from lookout.core.analyzer import Analyzer
+from lookout.core.helpers.analyzer_context_manager import AnalyzerContextManager
+
+
+class Reporter:
+    """
+    Base class to create performance reports for the analyzer.
+
+    To create a reporter for yours Analyzer you should inherit two classes.
+    1. Inherit SpyAnalyzer from Analyzer you want to estimate. SpyAnalyzer `analyze` function
+       should be overwritten to return all information you need for the next performance analysis
+       in the Comments with a JSON object. See `TyposAnalyzerSpy` as an example.
+    2. Inherit MyReporter from this Reporter class. It is expected that you have a dataset that
+       you feed to `Reprter.run()` method. After that dataset rows are passed to
+       `_trigger_review_event` to trigger Your analyzer analyze method and send a result to
+       `_generate_reports` method. If you need to summarize your reports or make a reduced report
+       override `_finalize` method.
+
+       Note, that if you want to create several reports for the data
+       (like test, train reports for example) you should properly override both
+       `get_report_names()` and `_generate_reports()` functions.
+    """
+
+    _log = logging.getLogger("Reporter")
+
+    # Reporter can work only with analyzers that provides json in output message.
+    inspected_analyzer_type = None  # type: Type[Analyzer]
+
+    def __init__(self, config: Optional[dict] = None, bblfsh: Optional[str] = None,
+                 database: Optional[str] = None, fs: Optional[str] = None):
+        """
+        Get new reporter instance.
+
+        If you want to use existing models and do not retrain them you should provide `database`
+        and 'fs' arguments.
+
+        :param config: Analyzer config to feed during push and review events. The analyzer uses \
+                       default config if not provided.
+        :param bblfsh: Babelfish endpoint to use by lookout-sdk.
+        :param database: Database endpoint to use to read and store information about models. \
+            Sqlite3 database in the temporary file is used if not provided.
+        :param fs: Model repository file system root. Temporary directory is used if not provided.
+        """
+        if not issubclass(self.inspected_analyzer_type, Analyzer):
+            raise AttributeError(
+                "inspected_analyzer_type attribute should we set to Analyzer class in %s reporter,"
+                " got %s." % (type(self), type(self.inspected_analyzer_type)))
+        self._config = config
+        self._bblfsh = bblfsh
+        self._database = database
+        self._fs = fs
+
+    def __enter__(self) -> "Reporter":
+        self._tmpdir = tempfile.mkdtemp("reporter-") \
+            if self._database is None or self._fs is None else None
+        if self._database is None:
+            self._database = os.path.join(self._tmpdir, "db.sqlite3")
+        if self._fs is None:
+            self._fs = os.path.join(self._tmpdir, "models")
+        os.makedirs(self._fs, exist_ok=True)
+        self._analyzer_context_manager = AnalyzerContextManager(
+            self.inspected_analyzer_type, db=self._database, fs=self._fs, init=False)
+        self._analyzer_context_manager.__enter__()
+        return self
+
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        self._analyzer_context_manager.__exit__()
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir)
+
+    def run(self, dataset: Sequence[Dict[str, Any]]) -> Iterator[Dict[str, str]]:
+        """
+        Run report generation.
+
+        :param dataset: The dataset for the report generation. The format is a list of data rows. \
+                        The row is a Dictionary with a mapping from the column name to its content.
+
+        :return: Iterator through generated reports. Each Generated report is extended with the \
+                 corresponding row data from the dataset.
+        """
+        def _run(dataset) -> Iterator[Dict[str, str]]:
+            for index, row in enumerate(dataset):
+                self._log.info("processing %d / %d (%s)", index, len(dataset), row)
+                try:
+                    fixes = self._trigger_review_event(row)
+                    reports = self._generate_reports(row, fixes)
+                    reports.update(row)
+                    yield reports
+                except Exception:
+                    self._log.exception("Failed to generate report %d / %d (%s)",
+                                        index, len(dataset), row)
+
+        self._log.info("processing %d entries", len(dataset))
+        yield from self._finalize(_run(dataset))
+
+    @classmethod
+    def get_report_names(cls) -> Tuple[str, ...]:
+        """
+        Get all available report names.
+
+        :return: Tuple with report names.
+        """
+        raise NotImplementedError()
+
+    def _generate_reports(self, dataset_row: Dict[str, Any], fixes: Sequence[NamedTuple],
+                          ) -> Dict[str, str]:
+        """
+        Generate reports for the dataset row.
+
+        :param dataset_row: Dataset row which triggered the analyze method of the analyzer.
+        :param fixes: List of data provided by the analyze method of spied analyzer.
+        :return: Dictionary with report names as keys and report string as values.
+        """
+        raise NotImplementedError()
+
+    def _trigger_review_event(self, dataset_row: Dict[str, Any]) -> Sequence[NamedTuple]:
+        """
+        Trigger review event and convert provided comments to internal representation.
+
+        It is required to call `Reporter._analyzer_context_manager.review()` in this function with
+        arguments you need and convert provided comments to a Sequence of NamedTuple-s for the
+        report generation.
+
+        :param dataset_row: Dataset row which triggers the analyze method of the analyzer.
+        :return: Sequence of data extracted from comments to generate report.
+        """
+        raise NotImplementedError()
+
+    def _finalize(self, reports: Iterable[Dict[str, str]]) -> Iterator[Dict[str, str]]:
+        """
+        Extend or Summarize generated reports if required.
+
+        Function provides reports as is by default.
+
+        :param reports: Iterable with generated reports.
+        :return: New finalized reports.
+        """
+        yield from reports

--- a/lookout/style/typos/benchmarks/__init__.py
+++ b/lookout/style/typos/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+"""
+The code and the data for the format IdTyposAnalyzer benchmarking and benchmarks generation.
+"""

--- a/lookout/style/typos/benchmarks/typo_commits_report.py
+++ b/lookout/style/typos/benchmarks/typo_commits_report.py
@@ -1,0 +1,193 @@
+"""Facilities to report the quality of a given model on a given dataset."""
+import csv
+import json
+import logging
+import os
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+
+
+from lookout.core.analyzer import ReferencePointer
+from lookout.core.api.service_analyzer_pb2 import Comment
+from lookout.core.api.service_data_pb2 import Change, File
+from lookout.core.data_requests import DataService, request_files
+import pandas
+
+from lookout.style.cloner import Cloner
+from lookout.style.format.benchmarks.quality_report import handle_input_arg
+from lookout.style.format.utils import generate_comment
+from lookout.style.reporter import Reporter
+from lookout.style.typos import IdTyposAnalyzer
+from lookout.style.typos.analyzer import TypoFix
+
+
+class TyposAnalyzerSpy(IdTyposAnalyzer):
+    """
+    The Analyzer which returns fixes found by IdTyposAnalyzer for all file content as JSON \
+    structures.
+    """
+
+    def run(self, ptr: ReferencePointer, data_service: DataService) -> Iterable[TypoFix]:
+        """
+        Run `generate_typos_fixes` for all lines and all files in ptr_from revision.
+
+        :param ptr: Git repository state pointer to the revision that should be analyzed.
+        :param data_service: Connection to the Lookout data retrieval service to get the files.
+        :return: Generator of fixes for each file.
+        """
+        files = request_files(data_service.get_data(), ptr,
+                              contents=True, uast=True, unicode=False)
+        return self.generate_typos_fixes([
+            Change(base=f, head=File(path=f.path, language=f.language)) for f in files])
+
+    def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
+                data_service: DataService, **data) -> List[Comment]:
+        """
+        Return the list of `TypoFix`-es as Comments.
+
+        `TypoFix`-es are generated with `run()` method.
+
+        :param ptr_from: The Git revision to analyze.
+        :param ptr_to: Not used. ptr_from is used for both model training and analysis.
+        :param data_service: The channel to the data service in Lookout server to query for \
+                             UASTs, file contents, etc.
+        :param data: Extra data passed into the method. Used by the decorators to simplify \
+                     the data retrieval.
+        :return: List of Typo Fixes information in a JSON format required for further analysis.
+        """
+        return [generate_comment(
+            filename=typo_fix.head_file.path,
+            line=typo_fix.line_number,
+            text=json.dumps(typo_fix._asdict()),
+            confidence=100) for typo_fix in self.run(ptr_from, data_service)]
+
+
+class TypoCommitsReporter(Reporter):
+    """
+    Report system for Typos Analyser.
+    """
+
+    inspected_analyzer_type = IdTyposAnalyzer
+
+    @classmethod
+    def get_report_names(cls) -> Tuple[str, ...]:
+        """
+        Get all available report names.
+
+        :return: Tuple with report names.
+        """
+        return ("report", )
+
+    def _generate_reports(self, dataset_row: Dict[str, Any], fixes: Sequence[TypoFix],
+                          ) -> Dict[str, str]:
+        """
+        Generate reports for the dataset row.
+
+        :param dataset_row: Dataset row which triggered the analyze method of the analyzer.
+        :param fixes: List of `TypoFix`-es provided by the `TyposAnalyzerSpy.analyze()` method.
+        :return: Dictionary with report names as keys and report string as values.
+        """
+        return {
+            "report": self.generate_commit_dataset_report(dataset_row, fixes),
+        }
+
+    def generate_commit_dataset_report(self, dataset_row: Dict[str, Any],
+                                       fixes: Sequence[TypoFix]) -> str:
+        """
+        Generate commit dataset report for the dataset row.
+
+        :param dataset_row: Dataset row which triggered the analyze method of the analyzer.
+        :param fixes: List of `TypoFix`-es provided by the `TyposAnalyzerSpy.analyze()` method.
+        :return: Dictionary with report names as keys and report string as values.
+        """
+        metrics = self.get_metrics_billet()
+
+        correct_fix = dataset_row["correct id"]
+        wrong_identifier = dataset_row["wrong id"]
+        for fix in fixes:
+            if fix.identifier == wrong_identifier:
+                if correct_fix in fix.identifier_candidates:
+                    metrics.detection_true_positive += 1
+                    metrics.fix_accuracy += 1
+            else:
+                metrics.detection_false_positive += 1
+        return json.dumps(metrics.to_dict())
+
+    def _trigger_review_event(self, dataset_row: Dict[str, Any]) -> Sequence[TypoFix]:
+        comments = self._analyzer_context_manager.review(
+            dataset_row["commit"], "HEAD", git_dir=dataset_row["repo"], bblfsh=self._bblfsh,
+            log_level="info", config_json=self._config)
+        typo_fixes = []
+        for comment in comments:
+            typo_fix_dict = json.loads(comment.text)
+            typo_fixes.append(TypoFix(head_file=typo_fix_dict["head_file"],
+                                      line_number=typo_fix_dict["line_number"],
+                                      candidates=typo_fix_dict["candidates"],
+                                      token=typo_fix_dict["token"]))
+        return typo_fixes
+
+    def _finalize(self, reports: Iterable[Dict[str, str]]) -> Iterator[Dict[str, str]]:
+        """
+        Summarize all individual reports to the final one.
+
+        :param reports: Reports generated by `TypoCommitsReporter.generate_commit_dataset_report()`
+        :return: Summarized final report
+        """
+        # TODO(zurk): Add a proper report
+        sum_metric = self.get_metrics_billet()
+        for report in reports:
+            sum_metric += pandas.Series(json.loads(report)["report"])
+        yield json.dumps(sum_metric.to_dict())
+
+    @staticmethod
+    def get_metrics_billet() -> pandas.Series:
+        """
+        Generate pandas series with TypoCommitsReporter metrics.
+
+        `detection_` prefix relates metric to typo detection and `fix_` to a metrics for founded
+        typos. Support is a number of analyzed identifiers.
+        """
+        metrics = ((
+            ("detection_true_positive", 0.0),
+            ("detection_false_positive", 0.0),
+            ("fix_accuracy", 0.0),
+            ("support", 0.0),
+        ))
+        index, defaults = zip(*metrics)
+        return pandas.Series(data=defaults, index=index)
+
+
+def generate_typos_report_entry(dataset: str, output: str, bblfsh: str, config: dict,
+                                database: Optional[str] = None, fs: Optional[str] = None,
+                                repos_cache: Optional[str] = None) -> None:
+    """
+    Entry point for command line interface to generate typos quality report for the given data.
+
+    :param dataset: csv file with commits to make report. Should contain repo, commit, file, \
+                    line, wrong id and correct id columns.
+    :param output: Directory where to save report.
+    :param bblfsh: bblfsh address to use by lookout-sdk.
+    :param config: config for IdTypoAnalyzer.
+    :param database: sqlite3 database path to store the models. Temporary file is used if not set.
+    :param fs: Model repository file system root. Temporary directory is used if not set.
+    :param repos_cache: Directory where to download repositories from the dataset. It is strongly \
+                        recommended to set this parameter if there are more then 20 repositories \
+                        required for report generation. Temporary directory is used if not set.
+    """
+    log = logging.getLogger("TyposReporter")
+    os.makedirs(output, exist_ok=True)
+    dataset = list(csv.DictReader(handle_input_arg(dataset)))
+    repositories = list(set(row["repo"] for row in dataset))
+    log.info("Generate report for dataset with %d entries", len(dataset))
+    repositories_path = Cloner(repos_cache).clone_repositories(repositories)
+    local_dataset = []
+    for entry in dataset:
+        if entry["repo"] in repositories_path:
+            local_dataset.append(dict(entry))
+            local_dataset[-1]["repo"] = repositories_path[entry["repo"]]
+    with TypoCommitsReporter(config, bblfsh, database, fs) as reporter:
+        reports = list(reporter.run(local_dataset))
+        for report in reports:
+            for report_name in reporter.get_report_names():
+                with open(os.path.join(output, "%s_%s_report.md" % (
+                        report["repo"], report_name)), "w") as f:
+                    f.write(report[report_name])


### PR DESCRIPTION
There are two main additions:
1. An abstraction layer for all Analyzer Reporters. Class that called `Reporter`
2. `TypoCommitsReporter` reported for the commit with typos dataset. 

Note, that `Reporter` takes fix information dirrectly from lookout-sdk which is more straightforward then before. 