### PR TITLE
Polish IdTyposAnalyzer

### DIFF
--- a/lookout/style/typos/utils.py
+++ b/lookout/style/typos/utils.py
@@ -144,7 +144,7 @@ def rank_candidates(candidates: pandas.DataFrame, pred_probs: Iterable[float],
     corrections = []
     for i in range(len(pred_probs)):
         index = candidates.loc[i, Columns.Id]
-        corrections.append(Candidate(candidates.loc[i, Columns.Candidate], pred_probs[i]))
+        corrections.append(Candidate(candidates.loc[i, Columns.Candidate], float(pred_probs[i])))
         if i < len(pred_probs) - 1 and candidates.loc[i + 1, Columns.Id] == index:
             continue
 


### PR DESCRIPTION
Minor changes to simplify work with an upcoming reporter.
1. The biggest limitation I am addressing is that `TypoFix` instance should be easily converted to a JSON object. So I exclude UAST from it.
2. Use `@with_changed_uasts_and_contents(unicode=True)`
3. Convert `pred_probs[i]` to float because it has `np.float` type which fails be converted to a JSON.
4. Remove `candidates` to `token_candidates` to be more specific. 