### PR TITLE
Fix parent bug

### DIFF
--- a/lookout/style/format/feature_extractor.py
+++ b/lookout/style/format/feature_extractor.py
@@ -803,7 +803,8 @@ class FeatureExtractor:
         for j, vn in enumerate(file_vnodes):
             if vn.node:
                 closest_left_node_id = id(vn.node)
-            parent = self._find_parent(j, file_vnodes, file_parents, closest_left_node_id)
-            if parent is None:
-                parent = uast
-            vnode_parents[id(vn)] = parent
+                vnode_parents[id(vn)] = file_parents[id(vn.node)]
+            else:
+                parent = (self._find_parent(j, file_vnodes, file_parents, closest_left_node_id)
+                          or uast)
+                vnode_parents[id(vn)] = parent

--- a/lookout/style/format/uast_stability_checker.py
+++ b/lookout/style/format/uast_stability_checker.py
@@ -101,7 +101,7 @@ class UASTStabilityChecker:
             if vnode.start.offset not in start_offset_to_vnodes:
                 # NOOP always included
                 start_offset_to_vnodes[vnode.start.offset] = i
-        for i, vnode in enumerate(vnodes[::-1]):
+        for i, vnode in enumerate(vnodes[::-1], start=1):
             if vnode.end.offset not in end_offset_to_vnodes:
                 # NOOP always included that is why we have reverse order in this loop
                 end_offset_to_vnodes[vnode.end.offset] = len(vnodes) - i
@@ -141,7 +141,6 @@ class UASTStabilityChecker:
             vnode_start_index = start_offset_to_vnodes[start]
             vnode_end_index = end_offset_to_vnodes[end]
 
-            assert vnode_start_index <= vnodes_i < vnode_end_index
             try:
                 content_after = self._code_generator.generate_one_change(
                     vnodes[vnode_start_index:vnode_end_index],


### PR DESCRIPTION
Fix #663. As mentioned during the sync, there were two bugs in our code but also the general invariant "A parent covers its children" is not respected in the js driver (comments can be outside of their parent).