### PR TITLE
Fix report metric calculation for typos analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ _install: &_install
   - find . -name tests -type d -exec chmod 555 {} \;
   - pip3 install git+https://github.com/facebookresearch/fastText@51e6738d734286251b6ad02e4fdbbcfe5b679382
   - pip3 uninstall -y modelforge
-  - pip3 install --no-warn-conflicts modelforge>=0.12
+  - pip3 install --no-warn-conflicts modelforge>=0.12.1
 _coverage: &_coverage
   - coverage run --concurrency=multiprocessing -m unittest discover
   - coverage combine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM srcd/lookout-sdk-ml:0.18.1
+FROM srcd/lookout-sdk-ml:0.19.0
 
 COPY requirements.txt style-analyzer/requirements.txt
 

--- a/lookout/style/reporter.py
+++ b/lookout/style/reporter.py
@@ -96,7 +96,6 @@ class Reporter:
         def _run(dataset) -> Iterator[Dict[str, str]]:
             for index, row in enumerate(huge_progress_bar(dataset, self._log, self._get_row_repr),
                                         start=1):
-                self._log.info("processing %d / %d (%s)", index, len(dataset), row)
                 try:
                     fixes = self._trigger_review_event(row)
                     reports = self._generate_reports(row, fixes)

--- a/lookout/style/typos/analyzer.py
+++ b/lookout/style/typos/analyzer.py
@@ -183,8 +183,7 @@ class IdTyposAnalyzer(Analyzer):
         return [node for node in extract_changed_nodes(uast, lines)
                 if (IDENTIFIER in node.roles and IMPORT not in node.roles and node.token)]
 
-    @staticmethod
-    def _find_new_lines(prev_content: str, content: str) -> List[int]:
+    def _find_new_lines(self, prev_content: str, content: str) -> List[int]:
         return find_new_lines(prev_content, content)
 
     def render_comment_text(self, typo_fix: TypoFix) -> str:

--- a/lookout/style/typos/analyzer.py
+++ b/lookout/style/typos/analyzer.py
@@ -28,12 +28,12 @@ from lookout.style.typos.utils import Candidate, Columns, flatten_df_by_column, 
 # TODO(zurk): Split TypoFix to FileFixes and TypoFix. content, path and identifiers_number should
 # be in the FileFixes.
 TypoFix = NamedTuple("TypoFix", (
-    ("content", str),                                         # file content from head revision
-    ("path", str),                                            # file path from head revision
-    ("line_number", int),                                     # line number for the comment
-    ("identifier", str),                                      # identifier where typo is found
-    ("candidates", Iterable[Candidate]),                      # suggested identifiers
-    ("identifiers_number", int),                              # Number of all analyzed identifiers
+    ("content", str),                                       # file content from head revision
+    ("path", str),                                          # file path from head revision
+    ("line_number", int),                                   # line number for the comment
+    ("identifier", str),                                    # identifier where typo is found
+    ("candidates", Iterable[Candidate]),                    # suggested identifiers
+    ("identifiers_number", int),                            # number of unique analyzed identifiers
 ))
 
 IDENTIFIER = bblfsh.role_id("IDENTIFIER")
@@ -143,7 +143,7 @@ class IdTyposAnalyzer(Analyzer):
                 except KeyError:
                     lines = []
                 else:
-                    lines = find_new_lines(prev_file.content, file.content)
+                    lines = self._find_new_lines(prev_file.content, file.content)
                 identifiers = self._get_identifiers(file.uast, lines)
                 new_identifiers = [node for node in identifiers
                                    if node.token not in self.allowed_identifiers]
@@ -175,13 +175,17 @@ class IdTyposAnalyzer(Analyzer):
                             identifier=identifier,
                             line_number=new_identifiers[index].start_position.line,
                             candidates=identifier_candidates,
-                            identifiers_number=len(identifiers),
+                            identifiers_number=len(set(n.token for n in new_identifiers)),
                         )
 
     @staticmethod
     def _get_identifiers(uast, lines):
         return [node for node in extract_changed_nodes(uast, lines)
                 if (IDENTIFIER in node.roles and IMPORT not in node.roles and node.token)]
+
+    @staticmethod
+    def _find_new_lines(prev_content: str, content: str) -> List[int]:
+        return find_new_lines(prev_content, content)
 
     def render_comment_text(self, typo_fix: TypoFix) -> str:
         """

--- a/lookout/style/typos/benchmarks/typo_commits_report.py
+++ b/lookout/style/typos/benchmarks/typo_commits_report.py
@@ -4,13 +4,14 @@ import json
 import logging
 from operator import itemgetter
 import os
+import pprint
 import time
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
 
-from lookout.core.analyzer import ReferencePointer, UnicodeChange
+from lookout.core.analyzer import ReferencePointer
 from lookout.core.api.service_analyzer_pb2 import Comment
-from lookout.core.api.service_data_pb2 import File
-from lookout.core.data_requests import DataService, request_files
+from lookout.core.api.service_data_pb2 import Change
+from lookout.core.data_requests import DataService, handle_analyze_rpc_errors, request_files
 import pandas
 from tabulate import tabulate
 
@@ -21,6 +22,7 @@ from lookout.style.format.utils import generate_comment
 from lookout.style.reporter import Reporter
 from lookout.style.typos import IdTyposAnalyzer
 from lookout.style.typos.analyzer import TypoFix
+from lookout.style.typos.model import IdTyposModel
 from lookout.style.typos.utils import TEMPLATE_DIR
 
 
@@ -32,6 +34,8 @@ class IdTyposAnalyzerSpy(IdTyposAnalyzer):
     Thus the result does not depend on base revision (`ptr_from`).
     """
 
+    _find_new_lines_return_value = None  # type: List[int]
+
     def run(self, ptr: ReferencePointer, data_service: DataService) -> Iterable[TypoFix]:
         """
         Run `generate_typos_fixes` for all lines and all files in `ptr_from` revision.
@@ -42,23 +46,33 @@ class IdTyposAnalyzerSpy(IdTyposAnalyzer):
         """
         for file in request_files(data_service.get_data(), ptr, contents=True, uast=True,
                                   unicode=False):
-            if file.path == self.config["filepath_to_analyze"]:
+            if file.path == self.config["analyze"]["filepath"]:
                 break
         else:
-            raise ValueError("No such file %s in %s" % (self.config["filepath_to_analyze"], ptr))
+            raise ValueError("No such file %s in %s" % (self.config["analyze"]["filepath"], ptr))
+        line = self.config["analyze"]["line"] + 1
+        try:
+            IdTyposAnalyzerSpy._find_new_lines_return_value = [line]
+            typos_fixes = list(self.generate_typos_fixes([Change(head=file, base=file)]))
+            line_identifiers = self._get_identifiers(file.uast, [line])
+            line_identifiers = [n.token for n in line_identifiers]
+            identifiers_number = len(set(line_identifiers))
+            if not identifiers_number:
+                raise ValueError("No identifiers for %s:%d in %s" % (
+                    self.config["analyze"]["filepath"], self.config["analyze"]["line"] + 1, ptr))
+            assert self.config["analyze"]["wrong_id"] in line_identifiers, \
+                "Identifier %s was not found in the %s:%d.\nLine identifiers are %s" % (
+                    self.config["analyze"]["wrong_id"], self.config["analyze"]["filepath"], line,
+                    line_identifiers)
+            if typos_fixes:
+                return typos_fixes
+            return [TypoFix(content=file.content.decode("utf-8", "replace"),
+                            path=file.path, line_number=0, identifier="", candidates=[],
+                            identifiers_number=identifiers_number)]
+        finally:
+            IdTyposAnalyzerSpy._find_new_lines_return_value = None
 
-        typos_fixes = list(self.generate_typos_fixes([
-            UnicodeChange(head=file, base=File(path=file.path, language=file.language))]))
-        if typos_fixes:
-            return typos_fixes
-        identifiers_number = len(self._get_identifiers(file.uast, []))
-        if not identifiers_number:
-            raise ValueError("No identifiers for file %s in %s" % (
-                self.config["filepath_to_analyze"], ptr))
-        return [TypoFix(content=file.content.decode("utf-8", "replace"),
-                        path=file.path, line_number=0, identifier="", candidates=[],
-                        identifiers_number=identifiers_number)]
-
+    @handle_analyze_rpc_errors
     def analyze(self, ptr_from: ReferencePointer, ptr_to: ReferencePointer,
                 data_service: DataService, **data) -> List[Comment]:
         """
@@ -74,17 +88,62 @@ class IdTyposAnalyzerSpy(IdTyposAnalyzer):
                      the data retrieval.
         :return: List of `Comment`-s with `TypoFix` in JSON format.
         """
-        return [generate_comment(
-            filename=typo_fix.path,
-            line=typo_fix.line_number,
-            text=json.dumps(typo_fix._asdict()),
-            confidence=100) for typo_fix in self.run(ptr_to, data_service)]
+        comments = []
+        id_to_fix = []
+        for typo_fix in self.run(ptr_from, data_service):
+            id_to_fix.append(typo_fix.identifier)
+            comments.append(generate_comment(
+                filename=typo_fix.path,
+                line=typo_fix.line_number,
+                text=json.dumps(typo_fix._asdict()),
+                confidence=100))
+        self._log.debug("Suggestion to fix %s.\nTypo %s in the set: %s", id_to_fix,
+                        self.config["analyze"]["wrong_id"],
+                        self.config["analyze"]["wrong_id"] in id_to_fix)
+        return comments
+
+    @classmethod
+    def train(cls, ptr: ReferencePointer, config: Mapping[str, Any], data_service: DataService,
+              **data) -> IdTyposModel:
+        """
+        Return empty model if check_all_identifiers is True.
+
+        It helps to speed up report generation. Such approach is not correct for original \
+        IdTyposAnalyzer but ok for Spy class.
+        """
+        if config.get("check_all_identifiers", True):
+            return IdTyposModel()
+        return super().train(ptr, config, data_service, **data)
+
+    @staticmethod
+    def _find_new_lines(prev_content: str, content: str) -> List[int]:
+        assert IdTyposAnalyzerSpy._find_new_lines_return_value is not None, \
+            "IdTyposAnalyzerSpy._find_new_lines_return_value should be set before " \
+            "_find_new_lines() call"
+        return IdTyposAnalyzerSpy._find_new_lines_return_value
 
 
 class TypoCommitsReporter(Reporter):
     """
     Report system for Typos Analyser.
     """
+
+    def __init__(self, config: Optional[dict] = None, bblfsh: Optional[str] = None,
+                 database: Optional[str] = None, fs: Optional[str] = None):
+        """
+        Initialize a new `TypoCommitsReporter` instance.
+
+        You should provide `database` and `fs` in order to re-use existing models (no training).
+
+        :param config: Analyzer configuration for push and review events. The analyzer uses \
+                       default config if not provided.
+        :param bblfsh: Babelfish endpoint to use by lookout-sdk.
+        :param database: Database endpoint to use to read and store information about models. \
+            Sqlite3 database in a temporary file is used if not provided.
+        :param fs: Model repository file system root. Temporary directory is used if not provided.
+        """
+        super().__init__(config, bblfsh, database, fs)
+        self._review_time = 0
 
     inspected_analyzer_type = IdTyposAnalyzerSpy
     report_template_path = os.path.join(TEMPLATE_DIR, "commits_with_typo_dataset_report.jinja2")
@@ -120,37 +179,53 @@ class TypoCommitsReporter(Reporter):
         :param fixes: List of `TypoFix`-es provided by the `TyposAnalyzerSpy.analyze()` method.
         :return: Dictionary with report names as keys and report string as values.
         """
-        metrics = self.get_metrics_stub()
-        metrics.review_time = self._review_time
         if not fixes:
             raise ValueError("Should be at least one fix.")
+
+        metrics = self.get_metrics_stub()
+        metrics.review_time = self._review_time
+        metrics.support = fixes[0].identifiers_number
+
         correct_fix = dataset_row["correct_id"]
         wrong_identifier = dataset_row["wrong_id"]
+        processed_tokens = set()
         for fix in fixes:
             if fix.identifier == "":
                 # no fixes where suggested
                 assert len(fixes) == 1
                 break
+            if fix.identifier in processed_tokens:
+                # We do not want to count the same fix twice
+                continue
             candidates = [candidate[0] for candidate in fix.candidates]
             best_candidate = max(fix.candidates, key=itemgetter(1))
             if fix.identifier == wrong_identifier:
                 if correct_fix in candidates:
                     metrics.detection_true_positive += 1
                     metrics.top3_fix_accuracy += 1
-                if correct_fix == best_candidate:
+                if correct_fix == best_candidate[0]:
                     metrics.fix_accuracy += 1
             else:
                 metrics.detection_false_positive += 1
+            processed_tokens.add(fix.identifier)
 
-        metrics.support = fixes[0].identifiers_number
         # Because there is one typo per commit
         metrics.detection_false_negatives = 1 - metrics.detection_true_positive
+        assert metrics.detection_false_negatives >= 0
+        self._log.info("the metrics for %s are\n%s", self._get_row_repr(dataset_row),
+                       pprint.pformat(metrics))
         return json.dumps(metrics.to_dict())
 
     def _trigger_review_event(self, dataset_row: Dict[str, Any]) -> Sequence[TypoFix]:
         config = merge_dicts(
             self._config if self._config is not None else {},
-            {IdTyposAnalyzerSpy.name: {"filepath_to_analyze": dataset_row["file"]}})
+            {IdTyposAnalyzerSpy.name: {
+                "check_all_identifiers": True,
+                "analyze": {
+                    "filepath": dataset_row["file"],
+                    "line": int(dataset_row["line"]),
+                    "wrong_id": dataset_row["wrong_id"],
+                }}})
         start_time = time.perf_counter()
         comments = self._analyzer_context_manager.review(
             dataset_row["commit_typo"], "HEAD", git_dir=dataset_row["repo_path"],
@@ -174,8 +249,8 @@ class TypoCommitsReporter(Reporter):
         scores.detection_recall = scores.detection_true_positive / (
             scores.detection_true_positive + scores.detection_false_negatives
         )
-        scores.fix_accuracy = scores.fix_accuracy / len(reports)
-        scores.top3_fix_accuracy = scores.top3_fix_accuracy / len(reports)
+        scores.fix_accuracy = scores.fix_accuracy / scores.detection_true_positive
+        scores.top3_fix_accuracy = scores.top3_fix_accuracy / scores.detection_true_positive
         scores.review_time = scores.review_time / len(reports)
 
         template = load_jinja2_template(self.report_template_path)
@@ -233,7 +308,7 @@ def generate_typos_report_entry(dataset: str, output: str, bblfsh: str, config: 
     """
     log = logging.getLogger("TyposReporter")
     os.makedirs(output, exist_ok=True)
-    dataset = list(csv.DictReader(handle_input_arg(dataset)))
+    dataset = list(csv.DictReader(handle_input_arg(dataset)))[0:10]
     repositories = sorted(set(row["repo"] for row in dataset))
 
     log.info("Generate report for dataset with %d entries", len(dataset))
@@ -251,4 +326,3 @@ def generate_typos_report_entry(dataset: str, output: str, bblfsh: str, config: 
                 with open(report_path, "w") as f:
                     f.write(report[report_name])
                 log.info("Report %s is saved to %s", report_name, report_path)
-    log.info("Done.")

--- a/lookout/style/typos/templates/commits_with_typo_dataset_report.jinja2
+++ b/lookout/style/typos/templates/commits_with_typo_dataset_report.jinja2
@@ -7,12 +7,12 @@
                          "detection_false_negatives",
                          "fix_accuracy", "top3_fix_accuracy", "support", "review_time"] %}
 {{ tabulate(scores[scores_to_show].to_frame(),
-            tablefmt="pipe", headers=["metric", "value"], floatfmt=".3f",
-            stralign="right", numalign="left") }}
+            tablefmt="pipe", headers=["metric", "value"], floatfmt=".3g",
+            stralign="right", numalign="decimal") }}
 
 {% if failures|length != 0 %}
-Report generation failed for
-{% for row_index in failures %}
+Report generation failed for {{ failures|length }} entries
+{% for row_index in failures|sort %}
 {{ row_index }}. {{ failures[row_index]["repo"] }}
 {% endfor %}
 {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sourced-ml==0.8.2
-lookout-sdk-ml==0.18.1
+lookout-sdk-ml==0.19.0
 scikit-learn==0.20.1
 scikit-optimize==0.5.2
 pandas==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     keywords=["machine learning on source code", "babelfish", "lookout"],
     install_requires=[
         "sourced-ml>=0.8.2,<0.9",
-        "lookout-sdk-ml>=0.18.1,<0.19",
+        "lookout-sdk-ml>=0.19.0,<0.20",
         "scikit-learn>=0.20,<2.0",
         "scikit-optimize>=0.5,<2.0",
         "pandas>=0.22,<2.0",


### PR DESCRIPTION
Closes https://github.com/src-d/style-analyzer/issues/704

With these fixes I was able to achieve the next numbers:
```
|                    metric | value    |
|--------------------------:|:---------|
|       detection_precision | 0.702    |
|          detection_recall | 0.495    |
|   detection_true_positive | 361.000  |
|  detection_false_positive | 153.000  |
| detection_false_negatives | 368.000  |
|              fix_accuracy | 0.909    |
|         top3_fix_accuracy | 1.000    |
|                   support | 2776.000 |
|               review_time | 9.148    |
```

I comment on each important moment in the self-review. 

Note, that I filter the dataset where typo was actually present on the expected line.