### PR TITLE
Print report in train_and_evaluate()

### DIFF
--- a/lookout/style/typos/preparation.py
+++ b/lookout/style/typos/preparation.py
@@ -245,7 +245,8 @@ def train_and_evaluate(train_data: pandas.DataFrame, test_data: pandas.DataFrame
                                embeddings_file=fasttext_path, config=generation_config)
     model.processes_number = processes_number
     model.train(train_data)
-    model.evaluate(test_data)
+    _, report = model.evaluate(test_data)
+    print(report)
     return model
 
 


### PR DESCRIPTION
Just print evaluation report to stdout (otherwise there's no much sense in evaluation except for saving the metrics to the model, if you don't count logs).