### PR TITLE
Add formatting for all metrics in typo report

### DIFF
--- a/lookout/style/common.py
+++ b/lookout/style/common.py
@@ -48,6 +48,9 @@ def load_jinja2_template(path: str) -> jinja2.Template:
         "pformat": pprint.pformat,
         "deepcopy": deepcopy,
     })
+    env.globals.update({
+        "zip": zip,
+    })
     root, name = os.path.split(path)
     loader = jinja2.FileSystemLoader((root,), followlinks=True)
     template = loader.load(env, name)

--- a/lookout/style/typos/benchmarks/typo_commits_report.py
+++ b/lookout/style/typos/benchmarks/typo_commits_report.py
@@ -207,8 +207,8 @@ class TypoCommitsReporter(Reporter):
             candidates = [candidate[0] for candidate in fix.candidates]
             best_candidate = max(fix.candidates, key=itemgetter(1))
             if fix.identifier == wrong_identifier:
+                metrics.detection_true_positive += 1
                 if correct_fix in candidates:
-                    metrics.detection_true_positive += 1
                     metrics.top3_fix_accuracy += 1
                 if correct_fix == best_candidate[0]:
                     metrics.fix_accuracy += 1

--- a/lookout/style/typos/templates/commits_with_typo_dataset_report.jinja2
+++ b/lookout/style/typos/templates/commits_with_typo_dataset_report.jinja2
@@ -2,11 +2,16 @@
 
 ## Metrics
 
-{% set scores_to_show = ["detection_precision", "detection_recall",
-                         "detection_true_positive", "detection_false_positive",
-                         "detection_false_negatives",
-                         "fix_accuracy", "top3_fix_accuracy", "support", "review_time"] %}
-{{ tabulate(scores[scores_to_show].to_frame(),
+{% set scores_to_show, formats = zip(("detection_precision", ".3f"),
+                                     ("detection_recall", ".3f"),
+                                     ("detection_true_positive", "d"),
+                                     ("detection_false_positive", "d"),
+                                     ("detection_false_negatives", "d"),
+                                     ("fix_accuracy",  ".3f"),
+                                     ("top3_fix_accuracy",  ".3f"),
+                                     ("support",  "d"),
+                                     ("review_time", "d")) %}
+{{ tabulate(scores[scores_to_show | list].to_frame(),
             tablefmt="pipe", headers=["metric", "value"], floatfmt=".3g",
             stralign="right", numalign="decimal") }}
 


### PR DESCRIPTION
I run a report and get such metrics: 
```
|                    metric |      value |
|--------------------------:|-----------:|
|       detection_precision |   0.699    |
|          detection_recall |   0.498    |
|   detection_true_positive | 370        |
|  detection_false_positive | 159        |
| detection_false_negatives | 373        |
|              fix_accuracy |   0.914    |
|         top3_fix_accuracy |   1        |
|                   support |   2.65e+03 |
|               review_time |  10.1      |
```
I do not like `2.65e+03` so I should regenerate it with this changes.
Also I include zip function to jinja2 template loading because it is not the first time we need this function.

Also I fix `detection_true_positive` metric calculation. It should not depend whether fix was correct or not.