### PR TITLE
Explicitly add xz support to smart_open

### DIFF
--- a/lookout/style/common.py
+++ b/lookout/style/common.py
@@ -1,11 +1,20 @@
 from copy import deepcopy
 from datetime import datetime
 import logging
+import lzma
 import os
 import pprint
 from typing import Callable, Iterator, Mapping, Sequence
 
 import jinja2
+from smart_open import register_compressor
+
+
+def add_xz_to_smart_open():
+    """Add .xz support to smart_open."""
+    def _handle_xz(file_obj, mode):
+        return lzma.LZMAFile(filename=file_obj, mode=mode, format=lzma.FORMAT_XZ)
+    register_compressor(".xz", _handle_xz)
 
 
 def merge_dicts(*dicts: Mapping) -> dict:

--- a/lookout/style/format/benchmarks/quality_report.py
+++ b/lookout/style/format/benchmarks/quality_report.py
@@ -17,7 +17,7 @@ import numpy
 from smart_open import smart_open
 from tabulate import tabulate
 
-from lookout.style.common import huge_progress_bar, merge_dicts
+from lookout.style.common import add_xz_to_smart_open, huge_progress_bar, merge_dicts
 from lookout.style.format.benchmarks.general_report import QualityReportAnalyzer
 from lookout.style.format.feature_extractor import FeatureExtractor
 
@@ -221,6 +221,7 @@ def handle_input_arg(input_arg: str, log: Optional[logging.Logger] = None) -> It
         for line in sys.stdin:
             yield line
     else:
+        add_xz_to_smart_open()
         with smart_open(input_arg, "r") as f:
             for line in f:
                 yield line

--- a/lookout/style/typos/symspell.py
+++ b/lookout/style/typos/symspell.py
@@ -5,6 +5,8 @@ import sys
 import numpy as np
 from smart_open import smart_open
 
+from lookout.style.common import add_xz_to_smart_open
+
 
 class SymSpell:
     """SymSpell: 1 million times faster through Symmetric Delete
@@ -127,6 +129,7 @@ class SymSpell:
             corpus (str): Path to .csv corpus file.
         """
         if os.path.exists(corpus):
+            add_xz_to_smart_open()
             with smart_open(corpus, "r") as f:
                 for line in csv.reader(f):
                     self._create_dictionary_entry(line[0], int(line[1]))

--- a/lookout/style/typos/utils.py
+++ b/lookout/style/typos/utils.py
@@ -8,6 +8,8 @@ import numpy
 import pandas
 from smart_open import smart_open
 
+from lookout.style.common import add_xz_to_smart_open
+
 
 Columns = NamedTuple(
     "Columns",
@@ -45,6 +47,7 @@ def print_frequencies(frequencies: Dict[str, int], path: str) -> None:
     :param frequencies: Dictionary of tokens' frequencies.
     :param path: Path to a .csv file to print frequencies to.
     """
+    add_xz_to_smart_open()
     with smart_open(path, "w") as f:
         writer = csv.writer(f)
         for line in sorted(frequencies.items(), key=lambda x: -x[1]):
@@ -59,6 +62,7 @@ def read_frequencies(file: str) -> Dict[str, int]:
     :return: Dictionary of tokens frequencies.
     """
     frequencies = {}
+    add_xz_to_smart_open()
     with smart_open(file, "r") as f:
         for line in csv.reader(f):
             frequencies[line[0]] = int(line[1])
@@ -73,6 +77,7 @@ def read_vocabulary(file: str) -> List[str]:
                  First token in every line split-by-space is added to the vocabulary. \
     :return: List of tokens of the vocabulary.
     """
+    add_xz_to_smart_open()
     with smart_open(file, "r") as f:
         tokens = [line[0] for line in csv.reader(f)]
     return tokens


### PR DESCRIPTION
The guys decided to roll back and remove `.xz` support, added by @vmarkovtsev.
