### PR TITLE
Add annotations to FeatureExtractor

### DIFF
--- a/lookout/style/format/annotations/__init__.py
+++ b/lookout/style/format/annotations/__init__.py
@@ -1,0 +1,7 @@
+"""
+Annotation tool.
+
+Inspired by https://uima.apache.org/d/uimafit-current/api/
+"""
+
+# TODO(zurk) move annotation module and tests to lookout-sdk-ml

--- a/lookout/style/format/annotations/annotated_data.py
+++ b/lookout/style/format/annotations/annotated_data.py
@@ -1,0 +1,329 @@
+from typing import Dict, Iterator, Optional, Tuple, Union, Type  # noqa F401
+
+from lookout.core.analyzer import UnicodeFile
+from sortedcontainers import SortedDict
+
+from lookout.style.format.annotations.annotations import Annotation, check_offset, check_span, \
+    LanguageAnnotation, PathAnnotation, UASTAnnotation
+
+
+class NoAnnotation(Exception):
+    """
+    Raised by `AnnotationManager` methods if there is no Annotation found.
+
+    See documentation about `AnnotationManager.find_overlapping_annotation()` or
+    `AnnotationManager.find_covering_annotation()` for more information.
+    """
+
+
+class AnnotationsSpan(dict):
+    """
+    Annotations collection for a specific span (or range).
+
+    Dictionary-like object.
+    """
+
+    def __init__(self, start, stop, *args, **kwargs):
+        """
+        Initialize a new instance of `AnnotationsSlice`.
+
+        :param start: Start of the span.
+        :param stop: End of the span. Stop point itself is excluded.
+        :param args: The rest position arguments are passed to `dict.__init__()`.
+        :param kwargs: The rest key arguments are passed to `dict.__init__()`.
+        """
+        check_span(start, stop)
+        super().__init__(*args, **kwargs)
+        self._span = (start, stop)
+        self._start = start
+        self._stop = stop
+
+    start = property(lambda self: self._start)
+
+    stop = property(lambda self: self._stop)
+
+    span = property(lambda self: self._span)
+
+
+class AnnotationManager:
+    """
+    Manager of `Annotation`-s for a text, e.g. source code.
+
+    All the methods to work with annotated data should be placed in this class.
+    Candidates can be found here:
+    https://uima.apache.org/d/uimafit-current/api/org/apache/uima/fit/util/JCasUtil.html
+    """
+
+    def __init__(self, sequence: str):
+        """
+        Initialize a new `AnnotationManager` instance.
+
+        :param sequence: Sequential data to annotate. It is expected to be string but can be any \
+                         type with __getitem__() defined for int and slice input arguments.
+        """
+        self._sequence = sequence
+
+        # Dictionary to store annotations for the whole file (aka `global` annotations)
+        self._global_annotations = {}  # type: Dict[Type[Annotation], Annotation]
+
+        # Next dictionaries are the main core of this class. The most common use-case we have in
+        # style-analyzer is iterating through Token annotations in the sorted order. That is why
+        # ordered dict is used.
+        # `self._type_to_annotations` is the main storage of the Annotations. It is a mapping
+        # from the annotation type to all annotations of this type which are are stored in the \
+        # dictionary that is sorted by spans.
+        # `self._span_to_annotations` dict is an optimization to quickly lookup all
+        # `Annotation`-s that belongs to the same [start, stop) span.
+        self._span_to_annotations = SortedDict()  # type: SortedDict[(int, int), Dict[Type[Annotation], Annotation]]  # noqa E501
+        self._type_to_annotations = {}  # type: Dict[Type[Annotation], SortedDict[(int, int), Annotation]]  # noqa E501
+
+    sequence = property(lambda self: self._sequence)
+
+    def __len__(self):
+        """Return the size of the underlying sequence."""
+        return len(self._sequence)
+
+    def __getitem__(self, item: Union[int, slice, Tuple[int, int]]) -> str:
+        """
+        Get the underlying sequence item or slice for the specified range.
+
+        :param item: index, slice or (start, stop) tuple.
+        :return: The corresponding part of the sequence.
+        """
+        if isinstance(item, tuple):
+            item = slice(*item)
+        if isinstance(item, slice) and item.step is not None:
+            raise KeyError("slice.step is not supported.")
+        return self._sequence[item]
+
+    def count(self, annotation_type: Type[Annotation]):
+        """Count the number of annotations of a specific type."""
+        try:
+            return len(self._type_to_annotations[annotation_type])
+        except KeyError:
+            return 0
+
+    def add(self, *annotations: Annotation) -> None:
+        """
+        Add multiple annotations.
+        """
+        for annotation in annotations:
+            self._add(annotation)
+
+    def _add(self, annotation: Annotation) -> None:
+        """
+        Add an annotation. Annotations of the same type may not overlap.
+        """
+        annotation_type = type(annotation)
+        if annotation.start == 0 and annotation.stop == len(self):
+            if annotation_type in self._global_annotations:
+                raise ValueError("Global annotation %s already exists" % annotation)
+            self._global_annotations[annotation_type] = annotation
+        else:
+            if annotation.span not in self._span_to_annotations:
+                self._span_to_annotations[annotation.span] = {}
+            if annotation_type not in self._type_to_annotations:
+                self._type_to_annotations[annotation_type] = SortedDict()
+            if self._type_to_annotations[annotation_type]:
+                right_span_index = self._type_to_annotations[annotation_type].bisect_left(
+                    annotation.span)
+                if right_span_index < len(self._type_to_annotations[annotation_type]):
+                    right_span, right_annotation = \
+                        self._type_to_annotations[annotation_type].peekitem(right_span_index)
+                    if self._check_spans_overlap(*right_span, *annotation.span):
+                        raise ValueError(
+                            "Trying to add Annotation %s which is overlaps with existing %s" % (
+                                right_annotation, annotation))
+                left_span_index = max(0, right_span_index - 1)
+                left_span, left_annotation = self._type_to_annotations[annotation_type].peekitem(
+                    left_span_index)
+                if self._check_spans_overlap(*left_span, *annotation.span):
+                    raise ValueError("Trying to add Annotation %s which is overlaps with existing"
+                                     "%s" % (left_annotation, annotation))
+            self._span_to_annotations[annotation.span][annotation_type] = annotation
+            self._type_to_annotations[annotation_type][annotation.span] = annotation
+
+    def get(self, annotation_type: Type[Annotation], span: Optional[Tuple[int, int]] = None,
+            ) -> Annotation:
+        """
+        Return an annotation for the given span and type.
+
+        Looking for an exact match only.
+
+        :param annotation_type: Annotation type to get.
+        :param span: Annotation span (range) to get. If span is not specified it returns an \
+                     annotation that cover all content (aka global annotation).
+        :return: Requested `Annotation`.
+        """
+        if span is None:
+            return self._global_annotations[annotation_type]
+        else:
+            check_span(*span)
+            return self._type_to_annotations[annotation_type][span]
+
+    def iter_annotations(self, annotation_type: Type[Annotation],
+                         *additional: Type[Annotation],
+                         start_offset: Optional[int] = None) -> Union[Iterator[AnnotationsSpan]]:
+        """
+        Iterate through annotations with specified type.
+
+        Iteration goes through `annotation_type`. It is additionally annotated with annotations
+        specified in `additional`. `additional` can't be empty. If you need to iterate through \
+        one annotation only use `AnnotationManager.iter_annotation()`.
+
+        :param annotation_type: Type of annotation to iterate through.
+        :param additional: Additional annotations that should be added to the main one.
+        :param start_offset: Start to iterate from the spesific offset. \
+                             Can be used as a key argument only.
+        :return: Iterator through annotations of requested types.
+        """
+        if not additional:
+            raise ValueError("At least one additional annotation should be specified. "
+                             "If you need to iterate through only one annotation use "
+                             "`iter_annotation()`.")
+        types = set(additional) | {annotation_type}
+        for annotation in self.iter_annotation(annotation_type, start_offset=start_offset):
+            # Annotations with the same span
+            same_span_annotations = self._span_to_annotations[annotation.span]
+            same_span_annotations_type = set(same_span_annotations.keys())
+            common_types = types & same_span_annotations_type
+            missing_types = types - same_span_annotations_type
+            annotations = dict()
+            for missing_type in missing_types:
+                try:
+                    annotations[missing_type] = self.find_covering_annotation(missing_type,
+                                                                              *annotation.span)
+                except NoAnnotation:
+                    pass
+            annotations.update({type: same_span_annotations[type] for type in common_types})
+            yield AnnotationsSpan(*annotation.span, annotations)
+
+    def iter_annotation(self, annotation_type: Type[Annotation], *,
+                        start_offset: Optional[int] = None) -> Iterator[Annotation]:
+        """
+        Iterate through a specific type of annotation.
+
+        If you need to iterate through several annotations use \
+        `AnnotationManager.iter_annotations()` instead.
+
+        :param annotation_type: Type of annotation to iterate through.
+        :param start_offset: Start to iterate from the spesific offset. \
+                             Can be used as a key argument only.
+        :return: Iterator through annotations of requested type.
+        """
+        search_from = 0
+        if start_offset is not None:
+            check_offset(start_offset, "start_offset")
+            search_from = self._type_to_annotations[annotation_type].bisect_left(
+                (start_offset, start_offset))
+        for value in self._type_to_annotations[annotation_type].values()[search_from:]:
+            yield value
+
+    def find_overlapping_annotation(self, annotation_type: Type[Annotation],
+                                    start: int, stop: int) -> Annotation:
+        """
+        Find an annotation of the given type that intersects the interval [start, stop).
+
+        :param annotation_type: Annotation type to look for.
+        :param start: Start of the search interval.
+        :param stop: End of the search interval. Stop point itself is excluded.
+        :raise NoAnnotation: There is no such annotation that overlaps with the given interval.
+        :return: `Annotation` of the requested type.
+        """
+        try:
+            annotation_layer = self._type_to_annotations[annotation_type]
+        except KeyError:
+            raise NoAnnotation("There is no annotation layer %s" % annotation_type)
+        check_span(start, stop)
+        search_start = max(0, annotation_layer.bisect_left((start, start)) - 1)
+        search_stop = annotation_layer.bisect_right((stop, stop))
+        for span in annotation_layer.islice(search_start, search_stop):
+            if self._check_spans_overlap(start, stop, *span):
+                # assuming that there is only one such annotation
+                return annotation_layer[span]
+        raise NoAnnotation("There is no annotation %s from %d to %d" % (
+            annotation_type, start, stop))
+
+    def find_covering_annotation(self, annotation_type: Type[Annotation],
+                                 start: int, stop: int) -> Annotation:
+        """
+        Find an annotation of the given type that fully covers the interval [start, stop).
+
+        :param annotation_type: Annotation type to look for.
+        :param start: Start of the search interval.
+        :param stop: End of the search interval. Stop point itself is excluded.
+        :raise NoAnnotation: There is no such annotation that overlaps with the given interval.
+        :return: `Annotation` of the requested type.
+        """
+        try:
+            annotation_layer = self._type_to_annotations[annotation_type]
+        except KeyError:
+            raise NoAnnotation("There is no annotation layer %s" % annotation_type)
+        check_span(start, stop)
+        search_start = max(0, annotation_layer.bisect_left((start, start)) - 1)
+        search_stop = annotation_layer.bisect_right((stop, stop))
+        for span_start, span_stop in annotation_layer.islice(search_start, search_stop):
+            if start == stop:
+                if self._check_spans_overlap(start, stop, span_start, span_stop):
+                    return annotation_layer[(span_start, span_stop)]
+            elif span_start <= start and stop <= span_stop:
+                # assuming that there is only one such annotation because they cannot overlap
+                return annotation_layer[(span_start, span_stop)]
+        raise NoAnnotation("There is no annotation %s that contains i%d to %d" % (
+            annotation_type, start, stop))
+
+    @classmethod
+    def _check_spans_overlap(cls, start1: int, stop1: int, start2: int, stop2: int) -> bool:
+        """
+        Check if two spans have at least 1 common point in their overlap.
+
+        Span 1 is [start1, stop1). `stop1` itself is excluded.
+        Span 2 is [start2, stop2). `stop2` itself is excluded.
+
+        Everywhere in next examples x < y < z.
+        Corner cases explained:
+        1. [x, y) and [y, z) have no overlap because y is excluded from the 1st interval.
+        2. 0-intervals:
+            2.1. [y, y) and [y, y) are overlapping because it is the same interval.
+            2.2. [y, y) and [y, z) have no overlap.
+            2.3. [x, y) and [y, y) have no overlap.
+            2.4. [x, z) and [y, y) are overlapping because [x, z) fully covers y point.
+
+        Despite the fact that overlapping rules are defined for 0-intervals it is not recommended \
+        to rely on them. If you want to get an additional annotation of the 0-interval annotation \
+        link one annotation to another. See `TokenAnnotation` as an example.
+
+        :param start1: Start offset of the first span.
+        :param stop1: Stop offset of the first span.
+        :param start2: Start offset of the second span.
+        :param stop2: Stop offset of the second span.
+        :return: True if spans are overlapping else False.
+        """
+        if start1 == stop1:
+            if start2 == stop2:
+                return start1 == start2
+            else:
+                return start2 < start1 < stop2
+        else:
+            if start2 == stop2:
+                return start1 < start2 < stop1
+            else:
+                return (start1 <= start2 < stop1 or
+                        start1 < stop2 < stop1 or
+                        start2 <= start1 < stop2)
+
+    @classmethod
+    def from_file(cls, file: UnicodeFile) -> "AnnotationManager":
+        """
+        Create `AnnotationManager` instance from `UnicodeFile`.
+
+        :param file: `file.content` will be used as data to be annotated with \
+                     `file.path`, `file.language` and `file.uast`.
+        :return: new AnnotationManager instance.
+        """
+        raw_data = file.content
+        annotated_data = AnnotationManager(raw_data)
+        annotated_data.add(PathAnnotation(0, len(raw_data), file.path))
+        annotated_data.add(UASTAnnotation(0, len(raw_data), file.uast))
+        annotated_data.add(LanguageAnnotation(0, len(raw_data), file.language))
+        return annotated_data

--- a/lookout/style/format/annotations/annotations.py
+++ b/lookout/style/format/annotations/annotations.py
@@ -1,0 +1,254 @@
+"""Annotations for style-analyzer."""
+from typing import FrozenSet, Optional, Tuple
+
+from lookout.style.format.utils import get_uast_parents
+
+
+def check_offset(value: int, name: str) -> None:
+    """
+    Check offset value for unexpected values as wrong type and negative.
+
+    :param value: Offset value to check.
+    :param name: Variable name for exception message.
+    :raises ValueError: if value is incorrect.
+    """
+    if not isinstance(value, int):
+        raise ValueError("Type of `%s` should be int. Get %s" % (name, type(value)))
+    if value < 0:
+        raise ValueError("`%s` should be non-negative. Get %d" % (name, value))
+
+
+def check_span(start: int, stop: int) -> None:
+    """
+    Check span value for unexpected values as wrong type and negative or wrong order.
+
+    :param start: Start offset of the span.
+    :param stop: Stop offset of the span.
+    :raises ValueError: if span value is incorrect.
+    """
+    check_offset(start, "start")
+    check_offset(stop, "stop")
+    if stop < start:
+        raise ValueError("`stop` should be not less than `start`. Get start=%d, stop=%d" % (
+            start, stop))
+
+
+class Annotation:
+    """Base class for all annotations."""
+
+    def __init__(self, start: int, stop: int):
+        """
+        Initialize a new instance of `Annotation`.
+
+        :param start: Start of the annotated span.
+        :param stop: End of the annotated span. Stop point itself is excluded.
+        """
+        check_span(start, stop)
+        self._start = start
+        self._stop = stop
+
+    start = property(lambda self: self._start)
+
+    stop = property(lambda self: self._stop)
+
+    span = property(lambda self: (self._start, self._stop))
+
+    name = property(lambda self: type(self).__name__)
+
+    def __repr__(self) -> str:
+        """Format `Annotation` object as a string."""
+        return self.__str__()
+
+    def __str__(self) -> str:
+        """Format `Annotation` description as a string."""
+        return "%s[%d, %d)" % (self.name, self.start, self.stop)
+
+
+class LineAnnotation(Annotation):
+    """
+    Line number annotation.
+
+    Line number in 1-based.
+    """
+
+    def __init__(self, start: int, stop: int, line: int):
+        """Initialize a new instance of `LineAnnotation`."""
+        super().__init__(start, stop)
+        if not isinstance(line, int):
+            raise ValueError("Type of `line` should be int. Get %s" % type(line))
+        if line < 1:
+            raise ValueError("`line` value should be positive. Get %d" % line)
+        self._line = line
+
+    line = property(lambda self: self._line)
+
+
+class UASTNodeAnnotation(Annotation):
+    """UAST Node annotation."""
+
+    def __init__(self, start: int, stop: int, node: "bblfsh.Node"):
+        """Initialize a new instance of `UASTNodeAnnotation`."""
+        super().__init__(start, stop)
+        self._node = node
+
+    node = property(lambda self: self._node)
+
+    @staticmethod
+    def from_node(node: "bblfsh.Node") -> "UASTNodeAnnotation":
+        """Create the annotation from `bblfsh.Node`."""
+        return UASTNodeAnnotation(node.start_position.offset, node.end_position.offset, node)
+
+
+class UASTAnnotation(UASTNodeAnnotation):
+    """Whole file UAST annotation."""
+
+    def __init__(self, start: int, stop: int, uast: "bblfsh.Node"):
+        """
+        Initialize a new instance of `UASTAnnotation`.
+
+        Parents mapping for the tree is built during init.
+
+        :param start: Annotation start.
+        :param stop: Annotation end.
+        :param uast: UAST of the file.
+        """
+        super().__init__(start, stop, uast)
+        self._parents = get_uast_parents(uast)
+
+    uast = property(lambda self: self._node)
+
+    parents = property(lambda self: self._parents)
+
+
+class TokenAnnotation(Annotation):
+    """Annotation for сode virtual token."""
+
+    def __init__(self, start: int, stop: int,
+                 uast_annotation: Optional[UASTNodeAnnotation] = None):
+        """
+        Initialize a new instance of `TokenAnnotation`.
+
+        `TokenAnnotation` can be 0-interval: [x, x). To avoid the complex search of related uast
+        annotation it is required to pass `UASTNodeAnnotation` to `__init__()`.
+
+        :param start: Annotation start.
+        :param stop: Annotation end.
+        :param uast_annotation: Related `UASTNodeAnnotation` if applicable.
+        """
+        super().__init__(start, stop)
+        self._uast_annotation = uast_annotation
+
+    uast_annotation = property(lambda self: self._uast_annotation)
+
+    @property
+    def node(self) -> "bblfsh.Node":
+        """
+        Get the UAST Node belonging to the underlying `UASTNodeAnnotation`.
+
+        :return: Related bblfsh UAST Node. None if there is no related `UASTNodeAnnotation`.
+        """
+        return self._uast_annotation.node if self._uast_annotation else None
+
+    @property
+    def has_node(self) -> bool:
+        """Check if token annotation has related UAST node annotation."""
+        return self._uast_annotation is not None
+
+
+class AtomicTokenAnnotation(TokenAnnotation):
+    """Annotation for indivisible tokens generated by `FeatureExtractor._classify_vnodes()`."""
+
+    def to_token_annotation(self) -> TokenAnnotation:
+        """Convert to `TokenAnnotation`."""
+        return TokenAnnotation(self.start, self.stop, self._uast_annotation)
+
+
+class RawTokenAnnotation(TokenAnnotation):
+    """Annotation for raw tokens generated by `FeatureExtractor._parse_file()`."""
+
+    def to_atomic_token_annotation(self) -> AtomicTokenAnnotation:
+        """Convert to `AtomicTokenAnnotation`."""
+        return AtomicTokenAnnotation(self.start, self.stop, self._uast_annotation)
+
+
+class LanguageAnnotation(Annotation):
+    """Language of the file annotation."""
+
+    def __init__(self, start: int, stop: int, language: str):
+        """Initialize a new instance of `LanguageAnnotation`."""
+        super().__init__(start, stop)
+        self._language = language
+
+    language = property(lambda self: self._language)
+
+
+class PathAnnotation(Annotation):
+    """File path annotation."""
+
+    def __init__(self, start: int, stop: int, path: str):
+        """Initialize a new instance of `PathAnnotation`."""
+        super().__init__(start, stop)
+        self._path = path
+
+    path = property(lambda self: self._path)
+
+
+class LabelAnnotation(Annotation):
+    """Label annotation that should be predicted by the ML model."""
+
+    def __init__(self, start: int, stop: int, label: Tuple[int, ...]):
+        """Initialize a new instance of `LabelAnnotation`."""
+        super().__init__(start, stop)
+        self._label = label
+
+    label = property(lambda self: self._label)
+
+
+class ClassAnnotation(Annotation):
+    """Class Annotation for atomic format symbols like quote, tab, space, etc."""
+
+    def __init__(self, start: int, stop: int, cls: Tuple[int, ...]):
+        """Initialize a new instance of `LabelAnnotation`."""
+        super().__init__(start, stop)
+        self._cls = cls
+
+    cls = property(lambda self: self._cls)
+
+    def to_target_annotation(self) -> LabelAnnotation:
+        """Convert annotation to `TargetAnnotation`."""
+        return LabelAnnotation(self.start, self.stop, self._cls)
+
+
+class AccumulatedIndentationAnnotation(Annotation):
+    """Annotation for "accumulated indentation" token."""
+
+
+class LinesToCheckAnnotation(Annotation):
+    """
+    Annotation to store a set of lines where the style shall be checked.
+
+    Lines are 1-based.
+    """
+
+    def __init__(self, start: int, stop: int, lines: FrozenSet[int]):
+        """Initialize a new instance of `LinesToCheckAnnotation`."""
+        super().__init__(start, stop)
+        for line in lines:
+            if not isinstance(line, int):
+                raise ValueError("Type of `line` should be int. Get %s" % type(line))
+            if line < 1:
+                raise ValueError("`line` value should be positive. Get %d" % line)
+        self._lines = lines
+
+    lines = property(lambda self: self._lines)
+
+
+class TokenParentAnnotation(Annotation):
+    """Annotation to store the UAST parent node of a token."""
+
+    def __init__(self, start: int, stop: int, parent: "bblfsh.Node"):
+        """Initialize a new instance of `TokenParentAnnotation`."""
+        super().__init__(start, stop)
+        self._parent = parent
+
+    parent = property(lambda self: self._parent)

--- a/lookout/style/format/benchmarks/expected_vnodes_number.py
+++ b/lookout/style/format/benchmarks/expected_vnodes_number.py
@@ -73,7 +73,7 @@ def get_vnodes_number(repository: str, from_commit: str, to_commit: str,
         with tempfile.TemporaryDirectory(prefix="top-repos-quality-repos-") as tmpdirname:
             git_dir = ensure_repo(repository, tmpdirname)
             try:
-                context.push(fr=from_commit, to=to_commit, git_dir=git_dir, log_level="warning",
+                context.push(fr=from_commit, to=to_commit, git_dir=git_dir, log_level="info",
                              bblfsh=bblfsh)
             except subprocess.CalledProcessError as e:
                 # Force stop expected

--- a/lookout/style/format/tests/bugs/002_bad_line_positions/test.py
+++ b/lookout/style/format/tests/bugs/002_bad_line_positions/test.py
@@ -2,10 +2,12 @@ from pathlib import Path
 import unittest
 
 import bblfsh
+from lookout.core.analyzer import UnicodeFile
 from lookout.core.bytes_to_unicode_converter import BytesToUnicodeConverter
 
 from lookout.style.format.analyzer import FormatAnalyzer
-from lookout.style.format.feature_extractor import FeatureExtractor
+from lookout.style.format.annotations.annotated_data import AnnotationManager
+from lookout.style.format.feature_extractor import FeatureExtractor, raw_file_to_vnodes_and_parents
 from lookout.style.format.tests.test_analyzer import get_config
 
 
@@ -24,7 +26,10 @@ class FeaturesTests(unittest.TestCase):
         converter = BytesToUnicodeConverter(code)
         code_uni = converter.convert_content()
         uast_uni = converter.convert_uast(uast)
-        nodes, parents = self.extractor._parse_file(code_uni, uast_uni, test_js_code_filepath)
+        file = UnicodeFile(content=code_uni, uast=uast_uni, language="javascript", path="test.js")
+        annotated_data = AnnotationManager.from_file(file)
+        self.extractor._parse_file(annotated_data)
+        nodes, _ = raw_file_to_vnodes_and_parents(annotated_data)
         for index, (node1, node2) in enumerate(zip(nodes, nodes[1:])):
             self.assertLessEqual(node1.start.line, node2.start.line,
                                  "Start line position decrease for %d, %d nodes" % (

--- a/lookout/style/format/tests/bugs/002_bad_line_positions/test.py
+++ b/lookout/style/format/tests/bugs/002_bad_line_positions/test.py
@@ -7,7 +7,7 @@ from lookout.core.bytes_to_unicode_converter import BytesToUnicodeConverter
 
 from lookout.style.format.analyzer import FormatAnalyzer
 from lookout.style.format.annotations.annotated_data import AnnotationManager
-from lookout.style.format.feature_extractor import FeatureExtractor, raw_file_to_vnodes_and_parents
+from lookout.style.format.feature_extractor import FeatureExtractor, file_to_old_parse_file_format
 from lookout.style.format.tests.test_analyzer import get_config
 
 
@@ -29,7 +29,7 @@ class FeaturesTests(unittest.TestCase):
         file = UnicodeFile(content=code_uni, uast=uast_uni, language="javascript", path="test.js")
         annotated_data = AnnotationManager.from_file(file)
         self.extractor._parse_file(annotated_data)
-        nodes, _ = raw_file_to_vnodes_and_parents(annotated_data)
+        nodes, _ = file_to_old_parse_file_format(annotated_data)
         for index, (node1, node2) in enumerate(zip(nodes, nodes[1:])):
             self.assertLessEqual(node1.start.line, node2.start.line,
                                  "Start line position decrease for %d, %d nodes" % (

--- a/lookout/style/format/tests/bugs/003_classify_vnodes_negative_col/test.py
+++ b/lookout/style/format/tests/bugs/003_classify_vnodes_negative_col/test.py
@@ -2,8 +2,11 @@ from pathlib import Path
 import unittest
 
 import bblfsh
+from lookout.core.api.service_data_pb2 import File
+from lookout.core.bytes_to_unicode_converter import BytesToUnicodeConverter
 
 from lookout.style.format.analyzer import FormatAnalyzer
+from lookout.style.format.annotations.annotated_data import AnnotationManager
 from lookout.style.format.feature_extractor import FeatureExtractor
 from lookout.style.format.tests.test_analyzer import get_config
 
@@ -20,10 +23,12 @@ class FeaturesTests(unittest.TestCase):
             code = f.read()
         uast = bblfsh.BblfshClient("0.0.0.0:9432").parse(
             filename="", language="javascript", contents=code).uast
-        nodes, parents = list(self.extractor._parse_file(code.decode("utf-8", "replace"),
-                                                         uast, test_js_code_filepath))
+        file = BytesToUnicodeConverter.convert_file(
+            File(content=code, uast=uast, language="javascript", path="test.js"))
+        annotated_data = AnnotationManager.from_file(file)
+        self.extractor._parse_file(annotated_data)
         # Just should not fail
-        list(self.extractor._classify_vnodes(nodes, "filepath"))
+        self.extractor._classify_vnodes(annotated_data)
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_annotations.py
+++ b/lookout/style/format/tests/test_annotations.py
@@ -1,0 +1,48 @@
+import unittest
+
+from lookout.style.format.annotations.annotated_data import AnnotationManager, AnnotationsSpan
+from lookout.style.format.annotations.annotations import AtomicTokenAnnotation, PathAnnotation
+
+
+class AnnotationsTests(unittest.TestCase):
+    def test_annotations(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        token_annotations = [AtomicTokenAnnotation(0, 3), AtomicTokenAnnotation(3, 3),
+                             AtomicTokenAnnotation(3, 4)]
+        path_annotation = PathAnnotation(0, len(code)-1, "1")
+        annotated_data.add(*token_annotations)
+        annotated_data.add(path_annotation)
+        annotations = list(annotated_data.iter_annotations(AtomicTokenAnnotation, PathAnnotation))
+        res = [AnnotationsSpan(0, 3, {AtomicTokenAnnotation: token_annotations[0],
+                                      PathAnnotation: path_annotation}),
+               AnnotationsSpan(3, 3, {AtomicTokenAnnotation: token_annotations[1],
+                                      PathAnnotation: path_annotation}),
+               AnnotationsSpan(3, 4, {AtomicTokenAnnotation: token_annotations[2],
+                                      PathAnnotation: path_annotation})]
+        self.assertEqual(annotations, res)
+
+    def test_check_interval_crossing(self):
+        data = [
+            ((9, 19), (19, 20), False),
+            ((19, 20), (9, 19), False),
+            ((1, 3), (2, 4), True),
+            ((2, 4), (1, 3), True),
+            ((-2, 4), (1, 3), True),
+            ((-2, 3), (1, 3), True),
+            ((1, 3), (1, 3), True),
+            ((1, 3), (6, 7), False),
+            ((10, 30), (6, 7), False),
+            ((10, 10), (10, 10), True),
+            ((10, 30), (10, 10), False),
+            ((10, 10), (10, 30), False),
+            ((10, 10), (5, 30), True),
+            ((5, 30), (10, 10), True),
+        ]
+        for i, (interval1, interval2, res) in enumerate(data):
+            self.assertEqual(AnnotationManager._check_spans_overlap(*interval1, *interval2),
+                             res, "Case # %d" % i)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lookout/style/format/tests/test_annotations.py
+++ b/lookout/style/format/tests/test_annotations.py
@@ -86,9 +86,10 @@ class AnnotationsTests(unittest.TestCase):
                                       AnotherAnnotation: another_annotation}),
                AnnotationsSpan(3, 4, {Annotation: annotations[2],
                                       AnotherAnnotation: another_annotation})]
-        self.assertEqual(list(annotated_data.iter_annotations(Annotation, AnotherAnnotation)), res)
+        self.assertEqual(list(annotated_data.iter_by_type_nested(
+            Annotation, AnotherAnnotation)), res)
 
-        annotations = list(annotated_data.iter_annotations(AnotherAnnotation, Annotation))
+        annotations = list(annotated_data.iter_by_type_nested(AnotherAnnotation, Annotation))
         res = [AnnotationsSpan(0, len(code)-1, {AnotherAnnotation: another_annotation})]
         self.assertEqual(annotations, res)
 
@@ -96,15 +97,15 @@ class AnnotationsTests(unittest.TestCase):
         code = "0123456789"
         annotated_data = AnnotationManager(code)
         with self.assertRaises(KeyError):
-            list(annotated_data.iter_annotation(Annotation))
+            list(annotated_data.iter_by_type(Annotation))
 
         annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
         annotated_data.add(*annotations[::-1])
-        self.assertEqual(list(annotated_data.iter_annotation(Annotation)),
+        self.assertEqual(list(annotated_data.iter_by_type(Annotation)),
                          annotations)
         more_annotations = [Annotation(0, 0), Annotation(4, 4), Annotation(4, 7)]
         annotated_data.add(*more_annotations)
-        self.assertEqual(list(annotated_data.iter_annotation(Annotation)),
+        self.assertEqual(list(annotated_data.iter_by_type(Annotation)),
                          sorted(annotations + more_annotations, key=lambda x: x.span))
 
     def test_find_overlapping_annotation(self):

--- a/lookout/style/format/tests/test_annotations.py
+++ b/lookout/style/format/tests/test_annotations.py
@@ -1,26 +1,147 @@
 import unittest
 
-from lookout.style.format.annotations.annotated_data import AnnotationManager, AnnotationsSpan
-from lookout.style.format.annotations.annotations import AtomicTokenAnnotation, PathAnnotation
+from lookout.style.format.annotations.annotated_data import AnnotationManager, AnnotationsSpan, \
+    NoAnnotation
+from lookout.style.format.annotations.annotations import Annotation, check_offset, check_span
+
+
+class AnotherAnnotation(Annotation):
+    pass
 
 
 class AnnotationsTests(unittest.TestCase):
-    def test_annotations(self):
+    def test_add(self):
         code = "0123456789"
         annotated_data = AnnotationManager(code)
-        token_annotations = [AtomicTokenAnnotation(0, 3), AtomicTokenAnnotation(3, 3),
-                             AtomicTokenAnnotation(3, 4)]
-        path_annotation = PathAnnotation(0, len(code)-1, "1")
-        annotated_data.add(*token_annotations)
-        annotated_data.add(path_annotation)
-        annotations = list(annotated_data.iter_annotations(AtomicTokenAnnotation, PathAnnotation))
-        res = [AnnotationsSpan(0, 3, {AtomicTokenAnnotation: token_annotations[0],
-                                      PathAnnotation: path_annotation}),
-               AnnotationsSpan(3, 3, {AtomicTokenAnnotation: token_annotations[1],
-                                      PathAnnotation: path_annotation}),
-               AnnotationsSpan(3, 4, {AtomicTokenAnnotation: token_annotations[2],
-                                      PathAnnotation: path_annotation})]
+        annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
+        another_annotation = AnotherAnnotation(0, len(code) - 1)
+        annotated_data.add(*annotations)
+        annotated_data.add(another_annotation)
+
+        overlapping_annotations = annotations + [
+            Annotation(0, 1), Annotation(1, 4), Annotation(3, 3), Annotation(2, 5)]
+        for annotation in overlapping_annotations:
+            with self.assertRaises(ValueError):
+                annotated_data.add(annotation)
+        ok_annotations = [Annotation(0, 0), Annotation(4, 4), Annotation(9, 11), Annotation(4, 9)]
+        for annotation in ok_annotations:
+            annotated_data.add(annotation)
+
+    def test_len(self):
+        self.assertEqual(0, len(AnnotationManager("")))
+        self.assertEqual(100, len(AnnotationManager(100*"1")))
+
+    def test_getitem(self):
+        am = AnnotationManager("")
+        self.assertEqual(am[:1], "")
+        with self.assertRaises(IndexError):
+            am[0]
+
+        seq = "0123456789"
+        am = AnnotationManager(seq)
+        self.assertEqual(am[0], seq[0])
+        self.assertEqual(am[0:5], seq[0:5])
+        self.assertEqual(am[(5, 7)], seq[5:7])
+        self.assertEqual(am[7:5], seq[7:5])
+        with self.assertRaises(IndexError):
+            am[len(seq)+1]
+
+    def test_count(self):
+        seq = "0123456789"
+        am = AnnotationManager(seq)
+
+        self.assertEqual(am.count(Annotation), 0)
+        am.add(Annotation(0, 1))
+        self.assertEqual(am.count(Annotation), 1)
+        am.add(Annotation(4, 5), Annotation(3, 4), Annotation(4, 4))
+        self.assertEqual(am.count(Annotation), 4)
+        self.assertEqual(am.count(AnotherAnnotation), 0)
+        am.add(AnotherAnnotation(4, 8))
+        self.assertEqual(am.count(Annotation), 4)
+        self.assertEqual(am.count(AnotherAnnotation), 1)
+        am.add(AnotherAnnotation(0, 3), AnotherAnnotation(3, 4), AnotherAnnotation(8, 8))
+        self.assertEqual(am.count(Annotation), 4)
+        self.assertEqual(am.count(AnotherAnnotation), 4)
+
+    def test_get(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        with self.assertRaises(Exception):
+            annotated_data.get(Annotation)
+        annotated_data.add(Annotation(4, 7))
+        annotated_data.get(Annotation, (4, 7))
+        with self.assertRaises(Exception):
+            annotated_data.get(Annotation)
+
+    def test_iter_annotations(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
+        another_annotation = AnotherAnnotation(0, len(code)-1)
+        annotated_data.add(*annotations[::-1])
+        annotated_data.add(another_annotation)
+        res = [AnnotationsSpan(0, 3, {Annotation: annotations[0],
+                                      AnotherAnnotation: another_annotation}),
+               AnnotationsSpan(3, 3, {Annotation: annotations[1],
+                                      AnotherAnnotation: another_annotation}),
+               AnnotationsSpan(3, 4, {Annotation: annotations[2],
+                                      AnotherAnnotation: another_annotation})]
+        self.assertEqual(list(annotated_data.iter_annotations(Annotation, AnotherAnnotation)), res)
+
+        annotations = list(annotated_data.iter_annotations(AnotherAnnotation, Annotation))
+        res = [AnnotationsSpan(0, len(code)-1, {AnotherAnnotation: another_annotation})]
         self.assertEqual(annotations, res)
+
+    def test_iter_annotation(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        with self.assertRaises(KeyError):
+            list(annotated_data.iter_annotation(Annotation))
+
+        annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
+        annotated_data.add(*annotations[::-1])
+        self.assertEqual(list(annotated_data.iter_annotation(Annotation)),
+                         annotations)
+        more_annotations = [Annotation(0, 0), Annotation(4, 4), Annotation(4, 7)]
+        annotated_data.add(*more_annotations)
+        self.assertEqual(list(annotated_data.iter_annotation(Annotation)),
+                         sorted(annotations + more_annotations, key=lambda x: x.span))
+
+    def test_find_overlapping_annotation(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
+        annotated_data.add(*annotations[::-1])
+        for annotation in annotations:
+            self.assertEqual(
+                annotated_data.find_overlapping_annotation(Annotation, *annotation.span),
+                annotation)
+        self.assertEqual(annotated_data.find_overlapping_annotation(Annotation, 1, 2),
+                         annotations[0])
+        self.assertEqual(annotated_data.find_overlapping_annotation(Annotation, 3, 5),
+                         annotations[2])
+        self.assertEqual(annotated_data.find_overlapping_annotation(Annotation, 2, 4),
+                         annotations[0])
+        for span in [(4, 4), (4, 5), (5, 5)]:
+            with self.assertRaises(NoAnnotation):
+                annotated_data.find_overlapping_annotation(Annotation, *span)
+
+    def test_find_covering_annotation(self):
+        code = "0123456789"
+        annotated_data = AnnotationManager(code)
+        annotations = [Annotation(0, 3), Annotation(3, 3), Annotation(3, 4)]
+        annotated_data.add(*annotations[::-1])
+        for annotation in annotations:
+            self.assertEqual(
+                annotated_data.find_covering_annotation(Annotation, *annotation.span),
+                annotation)
+        self.assertEqual(annotated_data.find_covering_annotation(Annotation, 1, 2),
+                         annotations[0])
+        self.assertEqual(annotated_data.find_covering_annotation(Annotation, 1, 1),
+                         annotations[0])
+        for span in [(4, 4), (4, 5), (5, 5), (3, 5), (2, 4)]:
+            with self.assertRaises(NoAnnotation):
+                annotated_data.find_covering_annotation(Annotation, *span)
 
     def test_check_interval_crossing(self):
         data = [
@@ -42,6 +163,34 @@ class AnnotationsTests(unittest.TestCase):
         for i, (interval1, interval2, res) in enumerate(data):
             self.assertEqual(AnnotationManager._check_spans_overlap(*interval1, *interval2),
                              res, "Case # %d" % i)
+
+    def test_annotations_span(self):
+        start = 10
+        stop = 20
+        span = AnnotationsSpan(start, stop)
+        self.assertEqual(span.start, start)
+        self.assertEqual(span.stop, stop)
+        self.assertEqual(span.span, (start, stop))
+        with self.assertRaises(AttributeError):
+            span.start = 11
+        with self.assertRaises(AttributeError):
+            span.stop = 21
+        with self.assertRaises(AttributeError):
+            span.span = (1, 2)
+
+    def test_check_span(self):
+        check_span(1, 2)
+        check_span(0, 20)
+        for span in [(-1, 1), (-10, -20), (-1, -1), (20, 10), ("a", 3), (1, 5.5)]:
+            with self.assertRaises(ValueError):
+                check_span(*span)
+
+    def test_check_offset(self):
+        check_offset(1, "offset")
+        check_offset(100, "offset")
+        for offset in [-1, -1000, "a", 5.4]:
+            with self.assertRaises(ValueError):
+                check_offset(offset, "offset")
 
 
 if __name__ == "__main__":

--- a/lookout/style/format/tests/test_expected_vnodes_number.py
+++ b/lookout/style/format/tests/test_expected_vnodes_number.py
@@ -3,6 +3,8 @@ import sys
 from tempfile import NamedTemporaryFile
 import unittest
 
+from modelforge import slogging
+
 from lookout.style.format.benchmarks.expected_vnodes_number import \
     calc_expected_vnodes_number_entry
 
@@ -11,6 +13,7 @@ class ExpectedVnodesTest(unittest.TestCase):
     @unittest.skipIf(sys.version_info.minor == 6, "We test python 3.6 inside docker container, "
                                                   "so there is no another docker inside.")
     def test_calc_expected_vnodes_number_entry(self):
+        slogging.setup("INFO", False)
         quality_report_repos_filepath = os.path.abspath(
             os.path.join(os.path.split(__file__)[0],
                          "../benchmarks/data/quality_report_repos.csv"))

--- a/lookout/style/format/tests/test_expected_vnodes_number.py
+++ b/lookout/style/format/tests/test_expected_vnodes_number.py
@@ -10,10 +10,12 @@ from lookout.style.format.benchmarks.expected_vnodes_number import \
 
 
 class ExpectedVnodesTest(unittest.TestCase):
+    def setUp(self):
+        slogging.setup("INFO", False)
+
     @unittest.skipIf(sys.version_info.minor == 6, "We test python 3.6 inside docker container, "
                                                   "so there is no another docker inside.")
     def test_calc_expected_vnodes_number_entry(self):
-        slogging.setup("INFO", False)
         quality_report_repos_filepath = os.path.abspath(
             os.path.join(os.path.split(__file__)[0],
                          "../benchmarks/data/quality_report_repos.csv"))

--- a/lookout/style/format/utils.py
+++ b/lookout/style/format/utils.py
@@ -81,3 +81,20 @@ def get_classification_report(y_pred: numpy.ndarray, y_true: numpy.ndarray,
             "report_full": report_full,
             "confusion_matrix": confusion_matrix,
             "target_names": target_names}
+
+
+def get_uast_parents(uast: "bblfsh.Node") -> Dict[int, "bblfsh.Node"]:
+    """
+    Create a mapping from id of the node in the UAST to its parent Node.
+
+    :param uast: UAST to get parents mapping for.
+    :return: Parents mapping.
+    """
+    parents = {}
+    queue = [uast]
+    while queue:
+        node = queue.pop()
+        for child in node.children:
+            parents[id(child)] = node
+        queue.extend(node.children)
+    return parents

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ tabulate==0.8.2
 python-igraph==0.7.1.post6
 smart-open==1.8.1
 joblib==0.13.2
+sortedcontainers==2.1.0  # TODO(zurk): move to lookout sdk ml
 git+https://github.com/facebookresearch/fastText@51e6738d734286251b6ad02e4fdbbcfe5b679382

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "python-igraph>=0.7.0,<2.0",
         "smart-open==1.8.1",
         "joblib>=0.13.2,<1.0",
+        "sortedcontainers>=2.1.0,<3.0",  # TODO(zurk): move to lookout-sdk-ml
     ],
     extras_require={
         "tf": tf_requires,


### PR DESCRIPTION
This PR adds Annotation tool to use instead of `VirtualNode` class (issue https://github.com/src-d/style-analyzer/issues/521).
PR contains:
- [All Annotation classes ](https://github.com/src-d/style-analyzer/pull/761/files#diff-22249ade799b2492702f2bc3bdb4868a) necessary for format analyzer.
- [AnnotationManager class](https://github.com/src-d/style-analyzer/pull/761/files#diff-f77b730022c0bcd23562b98a778c4585R48) which will be a replacement for the sequence of `VirtualNode`-s
- Most of the methods in the `FeatureExtractor` rewritten using `AnnotationManager`.
- Functions for backward compatibility. They are used to transform  `AnnotationManager` back to vnode sequence. They are going to be deleted after we finish refactoring. 

I also run a regression test to see if there any difference in old vnodes and new (restored) vnodes for quality report. 
I did not include the test to the PR. It can be found here: https://github.com/zurk/style-analyzer/commit/3aed7d1a7edf7e36e3155d372ceeae7928fcc85c
I see some improvements like there were a couple of bugs related to column position or mixed intention and the rest is the same. Also, the quality was almost the same for the first 15 repos from the report.
 
**The comparison with v0.2.0 report**
```
# Train Report comparison

|               repo |      precision |         recall |    full_recall |             f1 |        full_f1 |           ppcr |          support |     full_support |   Rules Number |   Average Rule Len |
|-------------------:|---------------:|---------------:|---------------:|---------------:|---------------:|---------------:|-----------------:|-----------------:|---------------:|-------------------:|
|          telescope | 1.000 (+0.000) | 1.000 (+0.000) | 0.210 (+0.000) | 1.000 (+0.000) | 0.348 (+0.000) | 0.210 (+0.000) |    203 (     +0) |    965 (     +0) |       2 (  +0) |         2.0 (+0.0) |
|              carlo | 0.934 (-0.043) | 0.934 (-0.043) | 0.623 (+0.053) | 0.934 (-0.043) | 0.747 (+0.027) | 0.667 (+0.083) |   5398 (   +670) |   8095 (     -3) |      34 ( +25) |         5.9 (+0.2) |
|          reveal.js | 0.965 (-0.010) | 0.965 (-0.010) | 0.655 (-0.014) | 0.965 (-0.010) | 0.781 (-0.012) | 0.679 (-0.006) |  10068 (    -97) |  14829 (     +0) |      19 (  -2) |         9.1 (-0.7) |
|   create-react-app | 0.977 (+0.000) | 0.977 (+0.000) | 0.474 (-0.001) | 0.977 (+0.000) | 0.639 (+0.000) | 0.485 (-0.002) |  11230 (    -28) |  23140 (     +0) |      14 (  +0) |         6.4 (+0.0) |
|              axios | 0.980 (+0.000) | 0.980 (+0.000) | 0.760 (+0.000) | 0.980 (+0.000) | 0.856 (+0.000) | 0.776 (+0.000) |  21335 (     +0) |  27482 (     +0) |      14 (  +0) |         7.4 (+0.0) |
|              redux | 0.972 (+0.000) | 0.972 (+0.000) | 0.571 (-0.003) | 0.972 (+0.000) | 0.719 (-0.003) | 0.588 (-0.002) |  23450 (   -104) |  39893 (     +0) |      17 (  +0) |         6.6 (-0.1) |
|              citgm | 0.962 (+0.000) | 0.962 (+0.000) | 0.825 (+0.000) | 0.962 (+0.000) | 0.888 (+0.000) | 0.857 (+0.000) |  20523 (     +0) |  23944 (     +0) |      59 (  +0) |         7.0 (+0.0) |
|          evergreen | 0.974 (+0.001) | 0.974 (+0.001) | 0.827 (+0.000) | 0.974 (+0.001) | 0.894 (+0.000) | 0.849 (-0.001) |  44342 (    -53) |  52233 (     +0) |     197 ( -20) |        11.0 (+0.0) |
| 30-seconds-of-code | 0.948 (+0.000) | 0.948 (+0.000) | 0.889 (+0.000) | 0.948 (+0.000) | 0.918 (+0.000) | 0.938 (+0.000) |  64537 (    -23) |  68832 (     +1) |      48 (  -3) |         7.9 (-0.2) |
|            express | 0.977 (+0.000) | 0.977 (+0.000) | 0.854 (+0.000) | 0.977 (+0.000) | 0.911 (+0.000) | 0.874 (+0.000) |  75137 (     +0) |  85947 (     +0) |      27 (  +0) |         7.8 (+0.0) |
|       freeCodeCamp | 0.960 (+0.000) | 0.960 (+0.000) | 0.828 (+0.000) | 0.960 (+0.000) | 0.889 (+0.000) | 0.863 (+0.000) | 105318 (     +0) | 122044 (     +0) |     153 (  -3) |        12.5 (+0.0) |
|          storybook | 0.973 (+0.000) | 0.973 (+0.000) | 0.832 (+0.000) | 0.973 (+0.000) | 0.897 (+0.000) | 0.855 (+0.000) | 163452 (     +4) | 191183 (     +0) |      57 (  +0) |         9.5 (-0.1) |
|             jquery | 0.977 (-0.002) | 0.977 (-0.002) | 0.885 (+0.006) | 0.977 (-0.002) | 0.929 (+0.003) | 0.907 (+0.009) | 202535 (  +1987) | 223414 (    +30) |     175 (+142) |        12.2 (+2.5) |
|            core-js | 0.985 (+0.000) | 0.985 (+0.000) | 0.959 (-0.001) | 0.985 (+0.000) | 0.972 (+0.000) | 0.974 (-0.001) | 302419 (   -305) | 310633 (     +0) |      66 (  -1) |         8.8 (+0.0) |
|               atom | 0.988 (+0.017) | 0.988 (+0.017) | 0.765 (-0.149) | 0.988 (+0.017) | 0.863 (-0.079) | 0.775 (-0.166) | 460543 ( +34428) | 594570 (+141858) |      62 (-326) |         9.2 (-1.7) | 

# Test Report comparison
|               repo |      precision |         recall |    full_recall |             f1 |        full_f1 |           ppcr |         support |    full_support |   Rules Number |   Average Rule Len |
|-------------------:|---------------:|---------------:|---------------:|---------------:|---------------:|---------------:|----------------:|----------------:|---------------:|-------------------:|
|          telescope | 0.826 (+0.000) | 0.826 (+0.000) | 0.457 (+0.000) | 0.826 (+0.000) | 0.588 (+0.000) | 0.553 (+0.000) |   172 (     +0) |   311 (     +0) |       2 (  +0) |         2.0 (+0.0) |
|              carlo | 0.883 (-0.064) | 0.883 (-0.064) | 0.756 (-0.005) | 0.883 (-0.064) | 0.814 (-0.030) | 0.856 (+0.052) |  1705 (   +104) |  1992 (     +0) |      34 ( +25) |         5.9 (+0.2) |
|          reveal.js | 0.949 (-0.005) | 0.949 (-0.005) | 0.774 (-0.004) | 0.949 (-0.005) | 0.853 (-0.004) | 0.816 (+0.001) |  8813 (    +10) | 10799 (     +0) |      19 (  -2) |         9.1 (-0.7) |
|   create-react-app | 0.912 (-0.002) | 0.912 (-0.002) | 0.746 (+0.002) | 0.912 (-0.002) | 0.821 (+0.001) | 0.818 (+0.003) |  3519 (    +14) |  4303 (     +0) |      14 (  +0) |         6.4 (+0.0) |
|              axios | 0.968 (+0.000) | 0.968 (+0.000) | 0.876 (+0.000) | 0.968 (+0.000) | 0.920 (+0.000) | 0.905 (+0.000) |  5166 (     +0) |  5707 (     +0) |      14 (  +0) |         7.4 (+0.0) |
|              redux | 0.924 (-0.001) | 0.924 (-0.001) | 0.828 (-0.012) | 0.924 (-0.001) | 0.874 (-0.006) | 0.896 (-0.012) |  4892 (    -64) |  5461 (     +0) |      17 (  +0) |         6.6 (-0.1) |
|              citgm | 0.921 (+0.000) | 0.921 (+0.000) | 0.910 (+0.000) | 0.921 (+0.000) | 0.915 (+0.000) | 0.988 (+0.000) |  5047 (     +0) |  5107 (     +0) |      59 (  +0) |         7.0 (+0.0) |
|          evergreen | 0.926 (+0.001) | 0.926 (+0.001) | 0.864 (+0.000) | 0.926 (+0.001) | 0.894 (+0.001) | 0.932 (-0.002) | 19934 (    -44) | 21381 (     +0) |     197 ( -20) |        11.0 (+0.0) |
| 30-seconds-of-code | 0.973 (+0.000) | 0.973 (+0.000) | 0.973 (+0.000) | 0.973 (+0.000) | 0.973 (+0.000) | 1.000 (+0.000) | 11493 (     +0) | 11493 (     +0) |      48 (  -3) |         7.9 (-0.2) |
|            express | 0.958 (+0.000) | 0.958 (+0.000) | 0.890 (+0.000) | 0.958 (+0.000) | 0.922 (+0.000) | 0.929 (+0.000) | 14453 (     +0) | 15557 (     +0) |      27 (  +0) |         7.8 (+0.0) |
|       freeCodeCamp | 0.929 (+0.000) | 0.929 (+0.000) | 0.894 (+0.000) | 0.929 (+0.000) | 0.911 (+0.000) | 0.962 (+0.000) | 23738 (     +0) | 24670 (     +0) |     153 (  -3) |        12.5 (+0.0) |
|          storybook | 0.957 (+0.000) | 0.957 (+0.000) | 0.899 (+0.000) | 0.957 (+0.000) | 0.927 (+0.000) | 0.939 (+0.000) | 33969 (     -1) | 36185 (     +0) |      57 (  +0) |         9.5 (-0.1) |
|             jquery | 0.969 (-0.008) | 0.969 (-0.008) | 0.933 (+0.002) | 0.969 (-0.008) | 0.950 (-0.003) | 0.963 (+0.010) | 46390 (   +478) | 48173 (     +0) |     175 (+142) |        12.2 (+2.5) |
|            core-js | 0.982 (+0.000) | 0.982 (+0.000) | 0.974 (-0.001) | 0.982 (+0.000) | 0.978 (-0.001) | 0.992 (-0.001) | 65767 (    -69) | 66293 (     +0) |      66 (  -1) |         8.8 (+0.0) |
|               atom | 0.961 (+0.012) | 0.961 (+0.012) | 0.937 (-0.007) | 0.961 (+0.012) | 0.949 (+0.002) | 0.975 (-0.019) | 88392 ( +70634) | 90636 ( +72776) |      62 (-326) |         9.2 (-1.7) |
```

I am going to run a full report for the final version after we merge. 