### PR TITLE
Expand typos quality report

### DIFF
--- a/lookout/style/typos/benchmarks/evaluate_typos.py
+++ b/lookout/style/typos/benchmarks/evaluate_typos.py
@@ -48,4 +48,4 @@ def evaluate_typos_on_identifiers(dataset: str = TYPOS_DATASET,
                            Candidate=Candidate, Columns=Columns,
                            tokenize=lambda x: list(analyzer.parser.split(x)),
                            flatten_df_by_column=flatten_df_by_column,
-                           generate_report=generate_report, logical_and=numpy.logical_and)
+                           generate_report=generate_report)

--- a/lookout/style/typos/benchmarks/evaluate_typos.py
+++ b/lookout/style/typos/benchmarks/evaluate_typos.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+import numpy
 import pandas
 
 from lookout.style.common import load_jinja2_template
@@ -47,4 +48,4 @@ def evaluate_typos_on_identifiers(dataset: str = TYPOS_DATASET,
                            Candidate=Candidate, Columns=Columns,
                            tokenize=lambda x: list(analyzer.parser.split(x)),
                            flatten_df_by_column=flatten_df_by_column,
-                           generate_report=generate_report)
+                           generate_report=generate_report, logical_and=numpy.logical_and)

--- a/lookout/style/typos/benchmarks/evaluate_typos.py
+++ b/lookout/style/typos/benchmarks/evaluate_typos.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
-import numpy
 import pandas
 
 from lookout.style.common import load_jinja2_template

--- a/lookout/style/typos/templates/quality_on_identifiers.md.jinja2
+++ b/lookout/style/typos/templates/quality_on_identifiers.md.jinja2
@@ -23,8 +23,17 @@ Checked tokens inside the vocabulary {{ tokens | intersect(vocabulary_tokens) | 
 
 ## Identifiers correction quality
 
-{% set s = {"cumsum": 0} %}
+{% set typoed = identifiers["wrong"].ne(identifiers["correct"]).values %}
+{% set corrected = identifiers["sugg 0"].ne(identifiers["wrong"]).values %}
+
+{% set accuracies = {-1: 0} %}
 {% for pos in range(n_candidates) %}
-{% do s.__setitem__("cumsum", s["cumsum"] + 100 * (identifiers["sugg " + pos|string].eq(identifiers["correct"]).mean())) %}
-{{ "%.2f%% of <=%d-th suggestions are correct " % (s["cumsum"], pos + 1) }}
+{% do accuracies.__setitem__(pos, accuracies[pos - 1] + 100 * (logical_and(identifiers["sugg " + pos|string].eq(identifiers["correct"]), typoed).sum() / typoed.sum())) %}
 {% endfor %}
+
+Detection precision | {{ "%.2f%%" % (100.0 * logical_and(corrected, typoed).sum() / corrected.sum()) }}
+Detection recall | {{ "%.2f%%" % (100.0 * logical_and(corrected, typoed).sum() / typoed.sum()) }}
+Total top1 accuracy | {{ "%.2f%%" % (100.0 * identifiers["sugg 0"].eq(identifiers["correct"]).mean())}}
+Top1 accuracy on typo-ed | {{ "%.2f%%" % accuracies[0] }}
+Top2 accuracy on typo-ed | {{ "%.2f%%" % accuracies[1] }}
+Top3 accuracy on typo-ed | {{ "%.2f%%" % accuracies[2] }}

--- a/lookout/style/typos/templates/quality_on_identifiers.md.jinja2
+++ b/lookout/style/typos/templates/quality_on_identifiers.md.jinja2
@@ -28,11 +28,11 @@ Checked tokens inside the vocabulary {{ tokens | intersect(vocabulary_tokens) | 
 
 {% set accuracies = {-1: 0} %}
 {% for pos in range(n_candidates) %}
-{% do accuracies.__setitem__(pos, accuracies[pos - 1] + 100 * (logical_and(identifiers["sugg " + pos|string].eq(identifiers["correct"]), typoed).sum() / typoed.sum())) %}
+{% do accuracies.__setitem__(pos, accuracies[pos - 1] + 100 * (identifiers["sugg " + pos|string].eq(identifiers["correct"]).__and__(typoed).sum() / typoed.sum())) %}
 {% endfor %}
 
-Detection precision | {{ "%.2f%%" % (100.0 * logical_and(corrected, typoed).sum() / corrected.sum()) }}
-Detection recall | {{ "%.2f%%" % (100.0 * logical_and(corrected, typoed).sum() / typoed.sum()) }}
+Detection precision | {{ "%.2f%%" % (100.0 * corrected.__and__(typoed).sum() / corrected.sum()) }}
+Detection recall | {{ "%.2f%%" % (100.0 * corrected.__and__(typoed).sum() / typoed.sum()) }}
 Total top1 accuracy | {{ "%.2f%%" % (100.0 * identifiers["sugg 0"].eq(identifiers["correct"]).mean())}}
 Top1 accuracy on typo-ed | {{ "%.2f%%" % accuracies[0] }}
 Top2 accuracy on typo-ed | {{ "%.2f%%" % accuracies[1] }}


### PR DESCRIPTION
Adapt identifier-level metrics for use with the dataset, which contains non-typo-ed identifiers (add detection metrics and split accuracy on total and on-typo-ed).