### PR TITLE
Fix cloner tests 

### DIFF
--- a/lookout/style/tests/test_cloner.py
+++ b/lookout/style/tests/test_cloner.py
@@ -45,8 +45,10 @@ class ClonerTests(unittest.TestCase):
             "failed to clone",
             "successfully cloned 5/6 repositories",
         ]
-        output = (json.loads(log_entry)["msg"] for log_entry in output)
-        output = [o for o in output if "| elapsed" not in o and "Using backend" not in o]
+        output = "\n".join((("}," if o == "}" else o) for o in output))
+        output = json.loads("[%s]" % output[:-1])
+        output = [o["msg"] for o in output
+                  if "| elapsed" not in o["msg"] and "Using backend" not in o["msg"]]
         self.assertEqual(len(output), len(expected_log))
         for expected_msg, log_msg in zip(expected_log, output):
             self.assertEqual(expected_msg, log_msg[:len(expected_msg)])


### PR DESCRIPTION
This commit address the recent changes in modelforge (https://github.com/src-d/modelforge/commit/9e10ff214ad356d4073ebadd6374df961ee88975)

The test expected to get each log entry at one line, but it is not the case now.

@vmarkovtsev actually, I am not sure that it is a good idea to have JSON logs formatted with new lines. JSON logs are for processing by design and not for humans. In other words, I think it is better to revert commit in modelforge rather than apply this fix. 