### PR TITLE
Fix protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+protobuf==3.7.1
 sourced-ml==0.8.2
 lookout-sdk-ml==0.19.1
 scikit-learn==0.20.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     namespace_packages=["lookout"],
     keywords=["machine learning on source code", "babelfish", "lookout"],
     install_requires=[
+        "protobuf==3.7.1",
         "sourced-ml>=0.8.2,<0.9",
         "lookout-sdk-ml>=0.19.1,<0.20",
         "scikit-learn>=0.20,<2.0",


### PR DESCRIPTION
This PR fixes failing tests (see https://travis-ci.com/src-d/style-analyzer/builds/114073628)

I found out that by compare Travis logs from the last succeeded build and the failed one. I am not sure what exactly was broken in the new release (https://github.com/protocolbuffers/protobuf/releases/tag/v3.8.0) but it was. 