### PR TITLE
Replace "on_corrected" with "on_typoed" in typos metrics

### DIFF
--- a/lookout/style/typos/templates/scores.md.jinja2
+++ b/lookout/style/typos/templates/scores.md.jinja2
@@ -1,7 +1,7 @@
 ### Typos correction report
 
 {% set scores = {" detection": get_scores(data, suggestions, ScoreMode.detection)} %}
-{% for mode in [ScoreMode.on_corrected, ScoreMode.correction] %}
+{% for mode in [ScoreMode.on_typoed, ScoreMode.correction] %}
         {% for k in range(1, 4) %}
             {% do scores.__setitem__("%s top %i" % (mode.value, k), get_scores(data, suggestions, mode, k)) %}
         {% endfor %}

--- a/lookout/style/typos/tests/test_metrics.py
+++ b/lookout/style/typos/tests/test_metrics.py
@@ -26,13 +26,12 @@ class MetricsTest(unittest.TestCase):
                            3: [Candidate("taken", 0.98), Candidate("token", 0.9)]}
 
     def test_get_score(self):
-
         self.assertDictEqual(get_scores(self.data, self.suggestions, ScoreMode.detection),
                              {"accuracy": 0.75, "precision": 2 / 3, "recall": 1.0, "f1": 0.8})
         self.assertDictEqual(get_scores(self.data, self.suggestions, ScoreMode.correction, k=1),
                              {"accuracy": 0.5, "precision": 0.5, "recall": 0.5, "f1": 0.5})
-        self.assertDictEqual(get_scores(self.data, self.suggestions, ScoreMode.on_corrected, k=2),
-                             {"accuracy": 2 / 3, "precision": 2 / 3, "recall": 1.0, "f1": 0.8})
+        self.assertDictEqual(get_scores(self.data, self.suggestions, ScoreMode.on_typoed, k=2),
+                             {"accuracy": 1.0, "precision": 1.0, "recall": 1.0, "f1": 1.0})
 
     def test_print_all_scores(self):
         report = generate_report(self.data, self.suggestions)


### PR DESCRIPTION
Measure correction quality on typo-ed tokens, not on the ones, that were corrected by the model. 

That's what we do in final reports and agreed upon several times.