### PR TITLE
Small change in fasttext training data generation

### DIFF
--- a/lookout/style/typos/config.py
+++ b/lookout/style/typos/config.py
@@ -28,6 +28,7 @@ DEFAULT_CORRECTOR_CONFIG = {
         "path": str(DEFAULT_DATA_DIR / "fasttext.bin"),  # Where to store trained fasttext model
         "dim": 10,  # Number of dimensions of embeddings
         "bucket": 200000,  # Number of hash buckets in the model
+        "adjust_frequencies": True,
     },
     "datasets": {
         "portion": 400000,

--- a/lookout/style/typos/config.py
+++ b/lookout/style/typos/config.py
@@ -28,7 +28,7 @@ DEFAULT_CORRECTOR_CONFIG = {
         "path": str(DEFAULT_DATA_DIR / "fasttext.bin"),  # Where to store trained fasttext model
         "dim": 10,  # Number of dimensions of embeddings
         "bucket": 200000,  # Number of hash buckets in the model
-        "adjust_frequencies": True,
+        "adjust_frequencies": True,  # Whether to divide identifiers frequencies by tokens number.
     },
     "datasets": {
         "portion": 400000,

--- a/lookout/style/typos/preparation.py
+++ b/lookout/style/typos/preparation.py
@@ -260,8 +260,9 @@ def train_fasttext(data: pandas.DataFrame, config: Optional[Mapping[str, Any]] =
     if config is None:
         config = {}
     config = merge_dicts(DEFAULT_CORRECTOR_CONFIG["fasttext"], config)
-    train_data = data[[len(str(x).split()) > 2 for x in data[Columns.Split]]].sample(
-        config["size"], weights=Columns.Frequency, replace=True)
+    lengths = data[Columns.Split].apply(lambda x: len(str(x).split()))
+    train_data = data[lengths > 1].sample(
+        config["size"], weights=data[Columns.Frequency] / lengths, replace=True)
     if config["corrupt"]:
         train_data = corrupt_tokens_in_df(train_data, config["typo_probability"],
                                           config["add_typo_probability"])


### PR DESCRIPTION
- Use real identifier frequencies for sampling - more fair distribution
- Use 2-tokens identifiers too, before it started only with 3